### PR TITLE
Remove one last mention of PER

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,9 +56,9 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
     <h2 class="notoc"><a id="abstract">Abstract</a></h2>
 
     <p>The mission of the World Wide Web Consortium (<abbr>W3C</abbr>) is to lead the World Wide Web to its full potential by
-      developing common protocols that promote its evolution and ensure its interoperability. The W3C Process Document describes 
+      developing common protocols that promote its evolution and ensure its interoperability. The W3C Process Document describes
       the organizational structure of the W3C and the processes related to the responsibilities and functions they exercise to
-      enable W3C to accomplish its mission. This document does not describe the internal workings of the Team or W3C's public 
+      enable W3C to accomplish its mission. This document does not describe the internal workings of the Team or W3C's public
       communication mechanisms.</p>
 
     <p>For more information about the W3C mission and the history of W3C, please refer to
@@ -85,7 +85,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
       <a href="https://github.com/w3c/w3process">all changes since March 2017 in diff format</a> is available, as is an earlier <a href="https://dvcs.w3.org/hg/AB/">log of changes in previous versions, from 2005-2014</a>.</p>
 
     <p>Comment is invited on the draft. Please file comments as issues in the
-      <a href="https://github.com/w3c/w3process/issues">w3c/w3process Github Repository</a>. 
+      <a href="https://github.com/w3c/w3process/issues">w3c/w3process Github Repository</a>.
       If you are unable to do this you may send them in email to
       <a href="mailto:public-w3process@w3.org">public-w3process@w3.org</a>
      (<a href="https://lists.w3.org/Archives/Public/public-w3process/">publicly archived</a>) or to
@@ -322,7 +322,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
       <h2 id="Intro">1 Introduction</h2>
 
       <p>Most W3C work revolves around the standardization of Web technologies. To accomplish this work, W3C follows processes that
-        promote the development of high-quality standards based on the <a href="#Consensus">consensus</a> of the Membership, Team, 
+        promote the development of high-quality standards based on the <a href="#Consensus">consensus</a> of the Membership, Team,
         and public. W3C processes promote fairness, responsiveness, and progress: all facets of the W3C mission.
         This document describes the processes W3C follows in pursuit of its mission.</p>
 
@@ -330,9 +330,9 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <a href="#RecsW3C">W3C Recommendation</a> - a Web standard.</p>
 
       <ol>
-        <li>People generate interest in a particular topic. For instance, Members express interest in the form 
+        <li>People generate interest in a particular topic. For instance, Members express interest in the form
           of <a href="#Submission">Member Submissions</a>, and the <a href="#Team">Team</a> monitors work inside and outside of W3C
-          for signs of interest. Also, W3C is likely to organize a <a href="#GAEvents">Workshop</a> to bring people together to 
+          for signs of interest. Also, W3C is likely to organize a <a href="#GAEvents">Workshop</a> to bring people together to
           discuss topics that interest the W3C community.</li>
         <li>When there is enough interest in a topic (e.g., after a successful Workshop and/or discussion on an
           <a href="#ACCommunication">Advisory Committee mailing list</a>), the Director announces the development of a proposal for
@@ -347,7 +347,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
           <a href="#Reports">technical reports</a>, test suites, and tutorials).</li>
         <li>Working Groups generally create specifications and guidelines that undergo cycles of revision and review as they
           <a href="#rec-advance">advance to W3C Recommendation</a> status. The W3C process for producing these technical reports
-          includes significant review by the Members and public, and requirements that the Working Group be able to show 
+          includes significant review by the Members and public, and requirements that the Working Group be able to show
           implementation and interoperability experience. At the end of the process, the Advisory Committee reviews the mature
           technical report, and if there is support, W3C publishes it as a <a href="#RecsW3C">Recommendation</a>.</li>
       </ol>
@@ -391,7 +391,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
             <li>elects 5 of the 9 participants on the <a href="#TAG">Technical Architecture Group</a>.</li>
           </ul>
 
-          Advisory Committee representatives <em class="rfc2119">may</em> initiate an 
+          Advisory Committee representatives <em class="rfc2119">may</em> initiate an
           <a href="#ACAppeal">Advisory Committee Appeal</a> in some cases described in this document.</li>
 
         <li>Representatives of Member organizations participate in <a href="#GAGeneral">Working Groups and Interest Groups</a> and
@@ -466,7 +466,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
       <p>For Member Consortia that have organizations as Members, all such designated representatives
         <em class="rfc2119">must</em> be an official representative of the Member organization
         (e.g. a Committee or Task Force Chairperson) and <em class="rfc2119">must</em> disclose their employment affiliation
-        when participating in W3C work. Provisions for <a href="#MemberRelated">related Members</a> apply. 
+        when participating in W3C work. Provisions for <a href="#MemberRelated">related Members</a> apply.
         Furthermore, these individuals <em class="rfc2119">must</em> represent the broad interests of the W3C Member organization
         and not the particular interests of their employers.</p>
 
@@ -516,7 +516,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         result in suspension of additional email addresses, at the discretion of the Team.</p>
 
       <h5 id="ACMeetings">2.1.3.2 Advisory Committee Meetings</h5>
-      <p>The Team organizes a <a href="#ftf-meeting">face-to-face meeting</a> for the Advisory Committee 
+      <p>The Team organizes a <a href="#ftf-meeting">face-to-face meeting</a> for the Advisory Committee
         <span class="time-interval">twice a year</span>. The Team appoints the Chair of these meetings (generally the CEO).
         At each Advisory Committee meeting, the Team <em class="rfc2119">should</em> provide an update to the
         Advisory Committee about:</p>
@@ -555,7 +555,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <dfn id="fellows">W3C Fellows</dfn> are Member employees working as part of the Team; see the
         <a href="https://www.w3.org/Consortium/Recruitment/Fellows">W3C Fellows Program</a> [<a href="#ref-fellows">PUB32</a>].
         The Team provides technical leadership about Web technologies, organizes and manages W3C activities to reach goals within
-        practical constraints (such as resources available), and communicates with the Members and the public about 
+        practical constraints (such as resources available), and communicates with the Members and the public about
         the Web and W3C technologies.</p>
       <p>The Director and CEO <em class="rfc2119">may</em> delegate responsibility (generally to other individuals in the Team)
         for any of their roles described in this document.</p>
@@ -590,7 +590,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <p>Created in March 1998, the Advisory Board provides ongoing guidance to the Team on issues of strategy, management,
         legal matters, process, and conflict resolution. The Advisory Board also serves the Members by tracking issues raised
-        between Advisory Committee meetings, soliciting Member comments on such issues, and proposing actions to resolve these 
+        between Advisory Committee meetings, soliciting Member comments on such issues, and proposing actions to resolve these
         issues. The Advisory Board manages the <a href="#GAProcess">evolution of the Process Document</a>. The Advisory Board hears
         a <a href="#SubmissionNo">Submission Appeal</a> when a Member Submission is rejected for reasons unrelated to Web
         architecture; see also the <a href="#TAG">TAG</a>.</p>
@@ -598,7 +598,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
       <p>The Advisory Board is <strong>not</strong> a board of directors and has no decision-making authority within W3C;
         its role is strictly advisory.</p>
 
-      <p>The Team <em class="rfc2119">must</em> make available a mailing list for the Advisory Board to use for its 
+      <p>The Team <em class="rfc2119">must</em> make available a mailing list for the Advisory Board to use for its
         communication,confidential to the Advisory Board and Team.</p>
 
       <p>The Advisory Board <em class="rfc2119">should</em> send a summary of each of its meetings to the Advisory Committee
@@ -606,7 +606,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <a href="#ACMeetings">Advisory Committee meeting</a>.</p>
 
       <p>Details about the Advisory Board (e.g., the list of Advisory Board participants, mailing list information, and
-        summaries of Advisory Board meetings) are available at the 
+        summaries of Advisory Board meetings) are available at the
         <a href="https://www.w3.org/2002/ab/">Advisory Board home page</a> [<a href="#ref-ab-home">PUB30</a>].</p>
 
       <h4 id="ABParticipation">2.3.1 Advisory Board Participation</h4>
@@ -726,20 +726,20 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         Single Transferable Vote system. An election begins when the Team sends a Call for Nominations to the Advisory Committee.
         Any Call for Nominations specifies the number of available seats, the deadline for nominations, details about the
         specific vote tabulation system selected by the Team for the election, and operational information such as how to
-        nominate a candidate. The Team 
+        nominate a candidate. The Team
         <em class="rfc2119">may</em> modify the  tabulation system after the Call for Nominations but
         <em class="rfc2119">must</em> stabilize it no later than the Call for Votes. The Director <em class="rfc2119">should</em>
         announce appointments no later than the start of a nomination period as part of the Call for Nominations.</p>
 
-      <p>Each Member (or group of <a href="#MemberRelated">related Members</a>) <em class="rfc2119">may</em> nominate one 
+      <p>Each Member (or group of <a href="#MemberRelated">related Members</a>) <em class="rfc2119">may</em> nominate one
         individual. A nomination <em class="rfc2119">must</em> be made with the consent of the nominee. In order for
-        an individual to be nominated as a Member representative, the individual <em class="rfc2119">must</em> qualify for 
+        an individual to be nominated as a Member representative, the individual <em class="rfc2119">must</em> qualify for
         <a href="#member-rep">Member representation</a> and the Member's Advisory Committee representative
         <em class="rfc2119">must</em> include in the nomination the (same)
         <a href="#member-rep-info">information required for a Member representative in a Working Group</a>. In order for an
         individual to be nominated as an Invited Expert, the individual <em class="rfc2119">must</em> provide the (same)
         <a href="#inv-expert-info">information required for an Invited Expert in a Working Group</a> and the nominating
-        Advisory Committee representative <em class="rfc2119">must</em> include that information in the nomination. 
+        Advisory Committee representative <em class="rfc2119">must</em> include that information in the nomination.
         In order for an individual to be nominated as a Team representative, the nominating Advisory Committee representative
         <em class="rfc2119">must</em> first secure approval from Team management. A nominee is
         <em class="rfc2119">not required</em> to be an employee of a Member organization, and <em class="rfc2119">may</em> be a
@@ -831,7 +831,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
       </ol>
       <p>Advisory Committee representatives who nominate individuals from their organization for participation in W3C activities
         are responsible for assessing and attesting to the qualities of those nominees.</p>
-      <p>See also the <a href="https://www.w3.org/Consortium/cepc/">W3C Code of Ethics and Professional Conduct</a> 
+      <p>See also the <a href="https://www.w3.org/Consortium/cepc/">W3C Code of Ethics and Professional Conduct</a>
        [<a href="#ref-cepc">PUB38</a>] and the participation requirements described in
         <a href="https://www.w3.org/Consortium/Patent-Policy#sec-Disclosure">section 6</a> of the
         <a href="https://www.w3.org/Consortium/Patent-Policy">W3C Patent Policy</a> [<a href="#ref-patentpolicy">PUB33</a>].</p>
@@ -972,7 +972,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <p>Where unanimity is not possible, a group <em class="rfc2119">should</em> strive to make consensus decisions where
         there is significant support and few abstentions. The Process Document does not require a particular percentage of
-        eligible participants to agree to a motion in order for a decision to be made. To avoid decisions where there is 
+        eligible participants to agree to a motion in order for a decision to be made. To avoid decisions where there is
         widespread apathy, (i.e., little support and many abstentions), groups <em class="rfc2119">should</em> set
         minimum thresholds of active support before a decision can be recorded. The appropriate percentage
         <em class="rfc2119">may</em> vary depending on the size of the group and the nature of the decision. A charter
@@ -1209,7 +1209,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
           <a href="/Guide/chair-roles">role of the Chair</a> is described in the
           <a href="https://www.w3.org/Guide/">Art of Consensus</a> [<a href="#ref-guide">PUB37</a>].</p>
         <p>Each group <em class="rfc2119">must</em> have a <dfn id="TeamContact">Team Contact</dfn>, who acts as the interface
-          between the Chair, group participants, and the rest of the Team. The 
+          between the Chair, group participants, and the rest of the Team. The
           <a href="/Guide/staff-contact">role of the Team Contact</a> is described in the Member guide. The Chair and the
           Team Contact of a group <em class="rfc2119">should not</em> be the same individual.</p>
         <p>Each group <em class="rfc2119">must</em> have an archived mailing list for formal group communication (e.g., for
@@ -1220,7 +1220,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <p>A Chair <em class="rfc2119">may</em> form task forces (composed of group participants) to carry out assignments for
           the group. The scope of these assignments <em class="rfc2119">must not</em> exceed the scope of the group's charter.
           A group <em class="rfc2119">should</em> document the process it uses to create task forces (e.g., each task force
-          might have an informal "charter"). Task forces do not publish <a href="#Reports">technical reports</a>; the 
+          might have an informal "charter"). Task forces do not publish <a href="#Reports">technical reports</a>; the
           Working Group <em class="rfc2119">may</em> choose to publish their results as part of a technical report.</p>
 
         <h3>5.2 <dfn id="GroupsWG">Working Groups</dfn> and <dfn id="GroupsIG">Interest Groups</dfn></h3>
@@ -1309,7 +1309,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <h5>5.2.1.3 <dfn id="invited-expert-wg">Invited Expert in a Working Group</dfn></h5>
 
         <p>The Chair <em class="rfc2119">may</em> invite an individual with a particular expertise to participate in a
-          Working Group. This individual <em class="rfc2119">may</em> represent an organization in the group 
+          Working Group. This individual <em class="rfc2119">may</em> represent an organization in the group
           (e.g., if acting as a liaison with another organization).</p>
 
         <p>An individual is an Invited Expert in a Working Group if all of the following conditions are satisfied:</p>
@@ -1493,7 +1493,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <p>These data <em class=rfc2119>must</em> be identified in the charter with the labels "Adopted Working Draft",
           "most recent Reference Draft", "most recent Candidate Recommendation", and "Other Charter", respectively.</p>
 
-        <p>The <dfn>Reference Draft</dfn> is the latest Working Draft published within 90 days of the 
+        <p>The <dfn>Reference Draft</dfn> is the latest Working Draft published within 90 days of the
           <a href="#first-wd">First Public Working Draft</a> or if no Public Working Draft has been published within
           90 days of the First Public Working Draft it is that First Public Working Draft. It is the specific draft against which
           exclusions are made, as per <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-exclusion-with">section 4.1</a>
@@ -1512,7 +1512,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
         <p id="ig-charter-participation">An Interest Group charter <em class="rfc2119">may</em> include provisions regarding
           participation, including specifying that the <dfn id="ig-mail-only">only requirement for participation (by anyone) in
-          the Interest Group is subscription to the Interest Group mailing list</dfn>. This type of Interest Group 
+          the Interest Group is subscription to the Interest Group mailing list</dfn>. This type of Interest Group
           <em class="rfc2119">may</em> have <a href="#public-participant-ig">public participants</a>.</p>
 
         <p>A charter <em class="rfc2119">may</em> include additional voting procedures, but those procedures
@@ -1643,7 +1643,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <g id="Rectrac-toCR" role="listitem" fill="#060">
         <a xlink:href="#Rectrac-nodeCR" aria-labelledby="Rectrac-tocr-label Rectrac-tocr-text">
-        <title id="Rectrac-tocr-label">Advance to Candidate Recommendation</title> 
+        <title id="Rectrac-tocr-label">Advance to Candidate Recommendation</title>
         <text role="none" id="Rectrac-tocr-text" x="138" y="134" font-size="8">Director's approval</text>
           <path stroke="#060" d="M135,140h81"></path>
           <polygon points="211,136 221,140 211,144"></polygon></a> </g>
@@ -1671,14 +1671,14 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <a xlink:href="#Rectrac-nodePR" id="Rectrac-ToPR"
         aria-labelledby="Rectrac-topr-label Rectrac-topr-text" fill="#060">
-        <title id="Rectrac-topr-label">Advance to Proposed Recommendation</title> 
+        <title id="Rectrac-topr-label">Advance to Proposed Recommendation</title>
         <text role="none" id="Rectrac-topr-text" x="300" y="134" font-size="8">Director's approval</text>
         <path d="M298,140h77" stroke="#060"></path>
         <polygon points="374,136 384,140 374,144"></polygon> </a>
 
       <a xlink:href="#Rectrac-nodeWD" id="Rectrac-backToWD"
         aria-labelledby="Rectrac-backtowd-label Rectrac-backtowd-text" fill="#600">
-        <title id="Rectrac-backtowd-label">Return to Working Draft</title> 
+        <title id="Rectrac-backtowd-label">Return to Working Draft</title>
         <text role="none" id="Rectrac-backtowd-text" font-size="8">
           <tspan x="142" y="160">WG or Director decision</tspan>
           <tspan x="144" y="170">e.g. for further review</tspan></text>
@@ -1696,8 +1696,8 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <a xlink:href="#Rectrac-nodeRec" id="Rectrac-ToRec" role="listitem"
         aria-labelledby="Rectrac-torec-label Rectrac-torec-text" fill="#060">
-        <title id="Rectrac-torec-label">Advance to Recommendation</title> 
-        <text role="none" id="Rectrac-torec-text" x="300" y="138" font-size="8">  
+        <title id="Rectrac-torec-label">Advance to Recommendation</title>
+        <text role="none" id="Rectrac-torec-text" x="300" y="138" font-size="8">
           <tspan x="445" y="124">Advisory Committee Review</tspan>
           <tspan x="445" y="134">Director's Decision</tspan></text>
 
@@ -1706,7 +1706,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <a xlink:href="#Rectrac-nodeCR" id="Rectrac-BackToCR" role="listitem"
         aria-labelledby="Rectrac-backtocr-label Rectrac-backtocr-text" fill="#600">
-        <title id="Rectrac-backtocr-label">Return to Working Draft</title> 
+        <title id="Rectrac-backtocr-label">Return to Working Draft</title>
         <text id="Rectrac-backtocr-text" font-size="8">
           <tspan x="306" y="160">AC Review, </tspan>
           <tspan x="302" y="170">Director Decision</tspan>
@@ -1716,7 +1716,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <a xlink:href="#Rectrac-nodeWD" id="Rectrac-PRBackToWD" role="listitem"
         aria-labelledby="Rectrac-prbacktowd-label Rectrac-prbacktowd-text" fill="#c00">
-        <title id="Rectrac-prbacktowd-label">Return to Working Draft</title> 
+        <title id="Rectrac-prbacktowd-label">Return to Working Draft</title>
         <text role="none" id="Rectrac-prbacktowd-text" font-size="9">
           <tspan x="90" y="202">Advisory Committee review and Director's Decision, e.g. for further work and review</tspan></text>
         <path d="M413,158v32h-316v-26" stroke-dasharray="2 2" stroke="#c00" fill="none"></path>
@@ -1780,14 +1780,14 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <dt id="RecsW3C">W3C Recommendation (REC)</dt>
         <dd>A W3C Recommendation is a specification or set of guidelines or requirements that, after extensive
           consensus-building, has received the endorsement of W3C Members and the Director. W3C recommends the wide deployment
-          of its Recommendations as standards for the Web. The W3C Royalty-Free IPR licenses granted under the 
+          of its Recommendations as standards for the Web. The W3C Royalty-Free IPR licenses granted under the
           <a href="https://www.w3.org/Consortium/Patent-Policy">W3C Patent Policy</a> [<a href="#ref-patentpolicy">PUB33</a>]
           apply to W3C Recommendations.</dd>
         <dt id="RecsObs">Obsolete Recommendation</dt>
          <dd>An Obsolete Recommendation is a specification that W3C does not believe has sufficient market relevance to continue
-         recommending that the community implement it, but does not consider that there are fundamental problems that require the 
+         recommending that the community implement it, but does not consider that there are fundamental problems that require the
          Recommendation be Rescinded. It is possible for an Obsolete Recommendation to receive sufficient market uptake that W3C
-         decides to restore it to Recommendation status. An Obsolete Recommendation has the same status as a W3C Recommendation 
+         decides to restore it to Recommendation status. An Obsolete Recommendation has the same status as a W3C Recommendation
          with regards to W3C Royalty-Free IPR licenses granted under the Patent Policy.</dd>
         <dt id="RescindedRec">Rescinded Recommendation</dt>
         <dd>A Rescinded Recommendation is an entire Recommendation that W3C no longer endorses, and believes is unlikely to ever
@@ -1862,7 +1862,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
           since the previous maturity level.</li>
         <li><em class="rfc2119">must</em> provide public documentation of any <a href="#FormalObjection">Formal Objections</a>.</li>
         <li><em class="rfc2119">should</em> provide public documentation of changes that are not substantive.</li>
-        <li><em class="rfc2119">should</em> report which, if any, of the Working Group's requirements for this document have 
+        <li><em class="rfc2119">should</em> report which, if any, of the Working Group's requirements for this document have
           changed since the previous step.</li>
         <li><em class="rfc2119">should</em> report any changes in dependencies with other groups.</li>
         <li><em class="rfc2119">should</em> provide information about implementations known to the Working Group.</li>
@@ -1872,7 +1872,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         approval is normally fairly automatic. For later stages, especially transition to Candidate or Proposed Recommendation,
         there is usually a formal review meeting to ensure the requirements have been met before Director's approval is given.</p>
 
-      <p>Transition Requests to First Public Working Draft or <a href="#last-call">Candidate Recommendation</a> will not normally 
+      <p>Transition Requests to First Public Working Draft or <a href="#last-call">Candidate Recommendation</a> will not normally
         be approved while a Working Group's charter is undergoing or awaiting a Director's decision on an
         Advisory Committee Review.</p>
 
@@ -1942,7 +1942,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <dd>These changes include fixing broken links, style sheets or invalid markup.</dd>
         <dt>2. Corrections that do not affect conformance</dt>
         <dd>Changes that reasonable implementers would not interpret as changing architectural or interoperability requirements
-          or their implementation. Changes which resolve ambiguities in the specification are considered to change 
+          or their implementation. Changes which resolve ambiguities in the specification are considered to change
           (by clarification) the implementation requirements and do not fall into this class.</dd>
         <dd>Examples of changes in this class include correcting non-normative code examples where the code clearly conflicts with
           normative requirements, clarifying informative use cases or other non-normative text, fixing typos or grammatical errors
@@ -2027,7 +2027,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <li><em class="rfc2119">must</em> document changes to dependencies during the development of the specification,</li>
         <li><em class="rfc2119">must</em> document how adequate <a href="#implementation-experience"> implementation experience</a>
           will be demonstrated,</li>
-        <li><em class="rfc2119">must</em> specify the deadline for comments, which <em class="rfc2119">must</em> be 
+        <li><em class="rfc2119">must</em> specify the deadline for comments, which <em class="rfc2119">must</em> be
           <strong>at least</strong> four weeks after publication, and <em class="rfc2119">should</em> be longer for
           complex documents,</li>
         <li><em class="rfc2119">must</em> show that the specification has received <a href="#wide-review">wide review</a>, and</li>
@@ -2077,7 +2077,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
           <em class="rfc2119">may</em> be removed before advancement to Proposed Recommendation without a requirement to publish a
           new Candidate Recommendation.</li>
       </ul>
-      <p>The Director <em class="rfc2119">must</em> announce the publication of a revised Candidate Recommendation to 
+      <p>The Director <em class="rfc2119">must</em> announce the publication of a revised Candidate Recommendation to
         other W3C groups and the Public.</p>
 
       <h3 id="rec-pr">6.5 Proposed Recommendation</h3>
@@ -2190,7 +2190,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <g id="Modif-toCR" role="listitem" fill="#060">
         <a xlink:href="#Modif-nodeCR" aria-labelledby="modif-tocr-label modif-tocr-text">
-        <title id="modif-tocr-label">Advance to Candidate Recommendation</title> 
+        <title id="modif-tocr-label">Advance to Candidate Recommendation</title>
         <text role="none" id="modif-tocr-text" x="138" y="136" font-size="8">Director's approval</text>
           <path stroke="#060" d="M135,140h81"></path>
           <polygon points="211,136 221,140 211,144"></polygon></a> </g>
@@ -2218,14 +2218,14 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <a xlink:href="#Modif-nodePR" id="Modif-ToPR"
         aria-labelledby="modif-topr-label modif-topr-text" fill="#060">
-        <title id="modif-topr-label">Advance to Proposed Recommendation</title> 
+        <title id="modif-topr-label">Advance to Proposed Recommendation</title>
         <text role="none" id="modif-topr-text" x="300" y="136" font-size="8">Director's approval</text>
         <path d="M298,140h77" stroke="#060"></path>
         <polygon points="374,136 384,140 374,144"></polygon> </a>
 
       <a xlink:href="#Modif-nodeWD" id="Modif-backToWD"
         aria-labelledby="modif-backtowd-label modif-backtowd-text" fill="#600">
-        <title id="modif-backtowd-label">Return to Working Draft</title> 
+        <title id="modif-backtowd-label">Return to Working Draft</title>
         <text role="none" id="modif-backtowd-text" font-size="8">
           <tspan x="140" y="160">WG or Director decision</tspan>
           <tspan x="142" y="172">e.g. for further review</tspan></text>
@@ -2243,8 +2243,8 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <a xlink:href="#Modif-nodeRec" id="Modif-ToRec" role="listitem"
         aria-labelledby="modif-torec-label modif-torec-text" fill="#060">
-        <title id="modif-torec-label">Advance to Recommendation</title> 
-        <text role="none" id="modif-torec-text" x="300" y="138" font-size="8">  
+        <title id="modif-torec-label">Advance to Recommendation</title>
+        <text role="none" id="modif-torec-text" x="300" y="138" font-size="8">
           <tspan x="445" y="128">Advisory Committee Review</tspan>
           <tspan x="445" y="136">Director's Decision</tspan></text>
 
@@ -2253,7 +2253,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <a xlink:href="#Modif-nodeCR" id="Modif-BackToCR" role="listitem"
         aria-labelledby="modif-backtocr-label modif-backtocr-text" fill="#600">
-        <title id="modif-backtocr-label">Return to Working Draft</title> 
+        <title id="modif-backtocr-label">Return to Working Draft</title>
         <text id="modif-backtocr-text" font-size="8">
           <tspan x="306" y="158">AC Review, </tspan>
           <tspan x="302" y="168">Director Decision</tspan>
@@ -2263,7 +2263,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <a xlink:href="#Modif-nodeWD" id="Modif-PRBackToWD" role="listitem"
         aria-labelledby="modif-prbacktowd-label modif-prbacktowd-text" fill="#c00">
-        <title id="modif-prbacktowd-label">Return to Working Draft</title> 
+        <title id="modif-prbacktowd-label">Return to Working Draft</title>
         <text role="none" id="modif-prbacktowd-text" font-size="9">
           <tspan x="92" y="202">Advisory Committee review and Director's Decision, e.g. for further work and review</tspan></text>
         <path d="M413,158v32h-316v-26" stroke-dasharray="2 2" stroke="#c00" fill="none"></path>
@@ -2284,7 +2284,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <polygon points="573,188 571,181 575,181"></polygon></a>
     </g>
   </g>
- 
+
 
 <g aria-labelledby="modif-overall-title">
  <title id="modif-overall-title">Initial maturity levels for a modification</title>
@@ -2387,9 +2387,9 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <h3 id="Note">6.8 Publishing a Working Group or Interest Group Note</h3>
 
-      <p>Working Groups and Interest Groups <em class="rfc2119">may</em> publish work as W3C Notes. Examples include:</p> 
+      <p>Working Groups and Interest Groups <em class="rfc2119">may</em> publish work as W3C Notes. Examples include:</p>
       <ul>
-        <li>supporting documentation for a specification, such as explanations of design principles or 
+        <li>supporting documentation for a specification, such as explanations of design principles or
           use cases and requirements,</li>
         <li>non-normative guides to good practices,
         <li>specifications where work has been stopped and there is no longer consensus for making them a new standard.</li>
@@ -2414,7 +2414,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <p>It is possible that W3C decides that implementing a particular Recommendation is no longer recommended.
         There are two designations for such specifications, chosen depending on how strongly W3C wishes to advise against
-        using the specification.</p> 
+        using the specification.</p>
 
       <p>W3C <em class="rfc2119">may</em> obsolete a Recommendation, for example if the W3C Community decides that
         the Recommendation no longer represents best practices, or is not adopted and is not apparently likely to be adopted.
@@ -2473,9 +2473,9 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         in the Advisory Committee review, the Director <em class="rfc2119">must</em> publish the substantive content of
         the dissent to W3C <strong>and the public</strong>, and <em class="rfc2119">must</em>
         <a href="#formal-address">formally address</a> the dissent at least 14 days before publication as an
-        Obsolete or Rescinded Recommendation.</p> 
+        Obsolete or Rescinded Recommendation.</p>
 
-      <p>The <a href="#AC">Advisory Committee</a> <em class="rfc2119">may</em> initiate an 
+      <p>The <a href="#AC">Advisory Committee</a> <em class="rfc2119">may</em> initiate an
         <a href="#ACAppeal">Advisory Committee Appeal</a> of the Director's decision.</p>
 
       <p>W3C <em class="rfc2119">must</em> publish an Obsolete or Rescinded Recommendation with up to date status.
@@ -2499,7 +2499,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
       <h2 id="ReviewAppeal">7 Advisory Committee Reviews, Appeals, and Votes</h2>
 
       <p>This section describes how the Advisory Committee reviews proposals from the Director and how Advisory Committee
-        representatives initiate an Advisory Committee Appeal of a W3C decision or Director's decision. A 
+        representatives initiate an Advisory Committee Appeal of a W3C decision or Director's decision. A
         <dfn id="def-w3c-decision">W3C decision</dfn> is one where the Director (or the Director's delegate) has exercised the role
         of assessing consensus after an <a href="#ACReview">Advisory Committee review</a>.</p>
 
@@ -2509,7 +2509,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <ul>
         <li><a href="#CharterReview">new and modified Working and Interest Groups</a>,</li>
-        <li><a href="#cfr">Proposed Recommendations</a>, <a href="#cfr-edited">Proposed Edited Recommendations</a>,
+        <li><a href="#cfr">Proposed Recommendations</a>,
           <a href="#proposed-rescinded-rec">Proposal to Rescind a Recommendation</a>, and</li>
         <li><a href="#GAProcess">Proposed changes to the W3C process</a>.</li>
       </ul>
@@ -2579,7 +2579,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
       <p>In all cases, an appeal <em class="rfc2119">must</em> be initiated within <span class="time-interval">three weeks</span>
         of the decision.</p>
 
-      <p>An Advisory Committee representative initiates an appeal by sending a request to the Team. Within one week the Team 
+      <p>An Advisory Committee representative initiates an appeal by sending a request to the Team. Within one week the Team
         <em class="rfc2119">must</em> announce the appeal process to the Advisory Committee and provide a mechanism for
         Advisory Committee representatives to respond with a statement of support (yes, no, or abstain) and comments, as desired.
         The archive of these comments <em class="rfc2119">must</em> be Member-visible. If, within
@@ -2608,7 +2608,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <p>The goal of a Symposium is usually to educate interested parties about a particular subject.</p>
 
-      <p>The Call for Participation in a Workshop or Symposium <em class="rfc2119">may</em> indicate participation requirements or 
+      <p>The Call for Participation in a Workshop or Symposium <em class="rfc2119">may</em> indicate participation requirements or
         limits, and expected deliverables (e.g., reports and minutes). Organization of an event does not guarantee further
         investment by W3C in a particular topic, but <em class="rfc2119">may</em> lead to proposals for
         new activities or groups.</p>
@@ -2667,7 +2667,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
           <ul>
             <li>If <a href="#SubmissionYes">acknowledged</a>, the Team <em class="rfc2119">must</em> publish the Member Submission
               at the public W3C Web site, in addition to Team comments about the Member Submission.</li>
-            <li>If <a href="#SubmissionNo">rejected</a>, the Submitter(s) <em class="rfc2119">may</em> initiate a 
+            <li>If <a href="#SubmissionNo">rejected</a>, the Submitter(s) <em class="rfc2119">may</em> initiate a
               <dfn>Submission Appeal</dfn> to either the <a href="#TAG">TAG</a> or the <a href="#AB">Advisory Board</a>.</li>
           </ul>
         </li>
@@ -2734,7 +2734,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <h4 id="SubmissionReqs">10.1.2 Information Required in a Submission Request</h4>
 
-      <p>The Submitter(s) and any other authors of the submitted material <em class="rfc2119">must</em> agree that, if the request 
+      <p>The Submitter(s) and any other authors of the submitted material <em class="rfc2119">must</em> agree that, if the request
         is acknowledged, the documents in the Member Submission will be subject to the
         <a href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document License</a>
         [<a href="#ref-doc-license">PUB18</a>] and will include a reference to it. The Submitter(s) <em class="rfc2119">may</em>
@@ -2786,7 +2786,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         Submission request and judged it complete and correct.</p>
 
       <p>Prior to a decision to <a href="#SubmissionYes">acknowledge</a> or <a href="#SubmissionNo">reject</a> the request, the
-        request is <a href="#Team-only">Team-only</a>, and the Team <em class="rfc2119">must</em> hold it in the strictest 
+        request is <a href="#Team-only">Team-only</a>, and the Team <em class="rfc2119">must</em> hold it in the strictest
         confidentiality. In particular, the Team <em class="rfc2119">must not</em> comment to the media about the Submission
         request.</p>
 
@@ -2851,7 +2851,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
           Proposed Process Document.
           The review period <em class="rfc2119">must</em> last at least <span class="time-interval">four weeks</span>.</li>
         <li><a href="#ACReviewAfter">After the Advisory Committee review</a>, if there is consensus, the Team enacts the new
-          process officially by announcing the <a href="#def-w3c-decision">W3C decision</a> to the Advisory Committee. 
+          process officially by announcing the <a href="#def-w3c-decision">W3C decision</a> to the Advisory Committee.
           Advisory Committee representatives <em class="rfc2119">may</em> initiate an
           <a href="#ACAppeal">Advisory Committee Appeal</a> to the W3C.</li>
       </ol>
@@ -2970,7 +2970,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
 
       <h2 id="acks">13 Acknowledgments</h2>
 
-      <p>The editor is grateful to the following people, 
+      <p>The editor is grateful to the following people,
         who as interested individuals and/or with the affiliation(s) listed,
         have contributed to this proposal for a revised Process: </p>
       <p>
@@ -2978,13 +2978,13 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         Paul Cotton (Microsoft),
         Virginia Fournier (Apple),
         Daniel Glazman (Disruptive Innovations),
-        Sadro Hawke (W3C), 
+        Sadro Hawke (W3C),
         Mark Nottingham,
-        Florian Rivoal (VivlioStyle), 
+        Florian Rivoal (VivlioStyle),
         Wendy Seltzer (W3C),
         David Singer (Apple), and
-        Léonie Watson (The Paciello Group).</p> 
-        
+        Léonie Watson (The Paciello Group).</p>
+
       <p>The editor is sorry for forgetting any names,
         and grateful to those who have listened patiently to conversations about this document
         without feeling a need to add more.</p>
@@ -2994,59 +2994,59 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         Dan Appelquist (Telefonica, unaffiliated),
         David Baron (Mozilla),
         Art Barstow (Nokia, unaffiliated),
-        Ann Bassetti (The Boeing Company), 
-        Jim Bell (HP), 
-        Robin Berjon (W3C), 
+        Ann Bassetti (The Boeing Company),
+        Jim Bell (HP),
+        Robin Berjon (W3C),
         Tim Berners-Lee (W3C),
         J Alan Bird (W3C),
         Klaus Birkenbihl (Fraunhofer Gesellschaft),
         Carine Bournez (W3C),
         Judy Brewer (W3C), Don Brutzman (Web3D),
-        Carl Cargill (Netscape, Sun Microsystems), 
+        Carl Cargill (Netscape, Sun Microsystems),
         Wayne Carr (Intel), Marcos Cáceres (Mozilla),
         Michael Champion (Microsoft),
         Paul Cotton (Microsoft),
         Maria Courtemanche (IBM),
         Mark Crawford (SAP),
         Geoffrey Creighton (Microsoft),
-        Tantek Çelik (Mozilla), Don Deutsch (Oracle), 
+        Tantek Çelik (Mozilla), Don Deutsch (Oracle),
         Karl Dubost (Mozilla),
         David Fallside (IBM), Fantasai (Mozilla),
         Kevin Fleming (Bloomberg),
         Wendy Fong (Hewlett-Packard), Virginie Galindo (Gemalto),
         Michael Geldblum (Oracle),
-        Daniel Glazman (Disruptive Innovations), Paul Grosso (Arbortext), 
+        Daniel Glazman (Disruptive Innovations), Paul Grosso (Arbortext),
         Eduardo Gutentag (Sun Microsystems), Joe Hall (CDT),
-        Ivan Herman (W3C), Ian Hickson (Google), 
-        Brad Hill (Facebook), Steve Holbrook (IBM), 
+        Ivan Herman (W3C), Ian Hickson (Google),
+        Brad Hill (Facebook), Steve Holbrook (IBM),
         Renato Iannella (IPR Systems),
-        Ian Jacobs (W3C), Jeff Jaffe (W3C), 
-        Cullen Jennings (Cisco), 
+        Ian Jacobs (W3C), Jeff Jaffe (W3C),
+        Cullen Jennings (Cisco),
         Brain Kardell (JQuery), Sally Khudairi (W3C),
         Jay Kishigami 岸上順一 (NTT),
         John Klensin (MCI), Tim Krauskopf (Spyglass),
-        Kari Laihonen (Ericsson), 
+        Kari Laihonen (Ericsson),
         Ken Laskey (MITRE), Ora Lassila (Nokia),
         Philippe LeHégaret (W3C),
-        Håkon Wium Lie (Opera Software), Chris Lilley (W3C), 
-        Peter Linss (HP), Bede McCall (MITRE), 
+        Håkon Wium Lie (Opera Software), Chris Lilley (W3C),
+        Peter Linss (HP), Bede McCall (MITRE),
         Giri Mandyam (Qualcomm),
         Larry Masinter (Adobe Systems), Nigel Megitt (BBC),
         Coralie Mercier (W3C),
-        Olle Olsson (SICS), 
-        Mark Nottingham, 
+        Olle Olsson (SICS),
+        Mark Nottingham,
         Qiuling Pan (Huawei),
-        Peter Patel-Schneider, 
-        Scott Peterson (Google), 
+        Peter Patel-Schneider,
+        Scott Peterson (Google),
         TV Raman (Google),
         Delfí Ramírez,
-        Thomas Reardon (Microsoft), Claus von Riegen (SAP AG), 
+        Thomas Reardon (Microsoft), Claus von Riegen (SAP AG),
         Natasha Rooney (GSMA), Sam Ruby (IBM),
         David Singer (Apple),
         David Singer (IBM), Henri Sivonen (Mozilla),
         Geoffrey Snedden,
-        Josh Soref (BlackBerry, unaffiliated), 
-        Ralph Swick (W3C), 
+        Josh Soref (BlackBerry, unaffiliated),
+        Ralph Swick (W3C),
         Anne van Kesteren,
         Jean-Charles Verdié (MStar),
         Léonie Watson (The Paciello Group),
@@ -3064,7 +3064,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
       <p>This document is based on the <a href="http://www.w3.org/2017/Process-20170301/">1 March 2017 Process</a>.
         <a href="https://github.com/w3/w3process/">Detailed logs of all changes</a> are available.</p>
 
-      <p>No substantive changes have yet been made, 
+      <p>No substantive changes have yet been made,
         compared to the <a href="http://www.w3.org/2017/Process-20170301/">1 March 2017 Process</a>.</p>
 
     </main>


### PR DESCRIPTION
PERs have disappeared from the document&hellip; except for this mention.
Removed.

(While at it, my editor removed trailing white spaces, which is a good thing, I think&nbsp;&mdash;&nbsp;[append `?w=1` to the &ldquo;files changed&rdquo; view](https://github.com/w3c/w3process/pull/42/files?w=1) to see the diff without those minor changes.)