### PR TITLE
say 28 days not four weeks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1400,7 +1400,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <p>The Director <em class="rfc2119">must</em> solicit <a href="#ACReview">Advisory Committee review</a> of every new or
           substantively modified Working Group or Interest Group charter. The Director is <em class="rfc2119">not required</em>
           to solicit Advisory Committee review prior to a charter extension or for minor changes. The review period
-          <em class="rfc2119">must</em> be at least four weeks.</p>
+          <em class="rfc2119">must</em> be at least 28 days.</p>
 
         <p>The Director's Call for Review of a substantively modified charter <em class="rfc2119">must</em> highlight
           important changes (e.g., regarding deliverables or resource allocation) and include rationale for the changes.</p>
@@ -1906,7 +1906,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         comments and the Working Group's responses, is generally a good practice which would often be considered
         positive evidence of wide review. Working Groups <em class="rfc2119">should</em> announce to other W3C Working Groups
         as well as the general public, especially those affected by this specification, a proposal to enter
-        <a href="#last-call">Candidate Recommendation</a> (for example in approximately four weeks). By contrast a
+        <a href="#last-call">Candidate Recommendation</a> (for example in approximately 28 days). By contrast a
         generic statement in a document requesting review at any time is likely not to be considered as sufficient evidence
         that the group has solicited wide review. </p>
 
@@ -2028,7 +2028,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <li><em class="rfc2119">must</em> document how adequate <a href="#implementation-experience"> implementation experience</a>
           will be demonstrated,</li>
         <li><em class="rfc2119">must</em> specify the deadline for comments, which <em class="rfc2119">must</em> be
-          <strong>at least</strong> four weeks after publication, and <em class="rfc2119">should</em> be longer for
+          <strong>at least</strong> 28 days after publication, and <em class="rfc2119">should</em> be longer for
           complex documents,</li>
         <li><em class="rfc2119">must</em> show that the specification has received <a href="#wide-review">wide review</a>, and</li>
         <li><em class="rfc2119">may</em> identify features in the document as "at risk". These features
@@ -2068,7 +2068,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <li><em class="rfc2119">must</em> show that the revised specification meets all Working Group requirements, or explain
           why the requirements have changed or been deferred,</li>
         <li><em class="rfc2119">must</em> specify the deadline for further comments, which <em class="rfc2119">must</em> be
-          <strong>at least</strong> four weeks after publication, and <em class="rfc2119">should</em> be longer for
+          <strong>at least</strong> 28 days after publication, and <em class="rfc2119">should</em> be longer for
           complex documents,</li>
         <li><em class="rfc2119">must</em> document the changes since the previous Candidate Recommendation, </li>
         <li><em class="rfc2119">must</em> show that the proposed changes have received <a href="#wide-review">wide review</a>,
@@ -2459,7 +2459,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <li>publish a rationale for the proposal</li>
         <li>identify known dependencies and solicit review from all dependent Working Groups</li>
         <li>solicit public review</li>
-        <li>specify the deadline for review comments, which <em class="rfc2119">must</em> be at least four weeks after
+        <li>specify the deadline for review comments, which <em class="rfc2119">must</em> be at least 28 days after
           the Director's announcement</li>
       </ul>
 
@@ -2849,7 +2849,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
         <li>After comments have been <a href="#formal-address">formally addressed</a> and the document possibly modified, the Team
           seeks endorsement from the Members by initiating an <a href="#ACReview">Advisory Committee review</a> of a
           Proposed Process Document.
-          The review period <em class="rfc2119">must</em> last at least <span class="time-interval">four weeks</span>.</li>
+          The review period <em class="rfc2119">must</em> last at least <span class="time-interval">28 days</span>.</li>
         <li><a href="#ACReviewAfter">After the Advisory Committee review</a>, if there is consensus, the Team enacts the new
           process officially by announcing the <a href="#def-w3c-decision">W3C decision</a> to the Advisory Committee.
           Advisory Committee representatives <em class="rfc2119">may</em> initiate an


### PR DESCRIPTION
fix #44

This should change all places where time requirements said "four weeks" to say "28 days"