### PR TITLE
Allow representation of multiple members

### DIFF
--- a/index.html
+++ b/index.html
@@ -1240,7 +1240,7 @@ Advisory Board, Working Group, Coordination Group, Interest Group, W3C Activity,
           <dfn id="public-participant-ig">public participants</dfn>.</p>
         <p>Except where noted in this document or in a group charter, all participants share the same rights and responsibilities
           in a group; see also the <a href="#ParticipationCriteria">individual participation criteria</a>.</p>
-        <p>A participant <em class="rfc2119">must</em> represent at most one organization in a Working Group or Interest Group.</p>
+
         <p>An individual <em class="rfc2119">may</em> become a Working or Interest Group participant at any time during the group's
           existence. See also relevant requirements in
           <a href="https://www.w3.org/Consortium/Patent-Policy#sec-join">section 4.3</a> of the


### PR DESCRIPTION
fix #9

This removes the constraint that a participant cannot represent more than one member.