### PR TITLE
A W3C Recommendation can be rescinded or obsolete

### DIFF
--- a/index.html
+++ b/index.html
@@ -2147,7 +2147,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
       <p>A W3C Recommendation normally retains its status indefinitely. However it</p>
       <ul>
         <li><em class="rfc2119">may</em> be republished as an <a href="#rec-modify">(Edited) Recommendation</a>, or</li>
-        <li><em class="rfc2119">may</em> be <a href="#rec-rescind">rescinded</a>.</li>
+        <li><em class="rfc2119">may</em> be <a href="#rec-rescind">rescinded or obsolete</a>.</li>
       </ul>
 
       <h3 id="rec-modify">6.7 Modifying a W3C Recommendation</h3>

--- a/index.html
+++ b/index.html
@@ -2147,7 +2147,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
       <p>A W3C Recommendation normally retains its status indefinitely. However it</p>
       <ul>
         <li><em class="rfc2119">may</em> be republished as an <a href="#rec-modify">(Edited) Recommendation</a>, or</li>
-        <li><em class="rfc2119">may</em> be <a href="#rec-rescind">rescinded or obsolete</a>.</li>
+        <li><em class="rfc2119">may</em> be <a href="#rec-rescind">rescinded or declared obsolete</a>.</li>
       </ul>
 
       <h3 id="rec-modify">6.7 Modifying a W3C Recommendation</h3>


### PR DESCRIPTION
Mention obsolete recommendation in [§ 6.6 W3C Recommendation](https://w3c.github.io/w3process/#rec-publication).