### PR TITLE
s/only contains/contains only/

### DIFF
--- a/index.html
+++ b/index.html
@@ -1758,7 +1758,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
           and do not imply any endorsement by W3C or its members beyond agreement to work on a general area of technology.</dd>
         <dt id="RecsCR">Candidate Recommendation (CR)</dt>
         <dd class="changed">A Candidate Recommendation is a document that satisfies the technical
-          requirements from the Working Group or only contains substantive corrections if there is no Working Group,
+          requirements from the Working Group or contains only substantive corrections if there is no Working Group,
           and has already received wide review. W3C publishes a Candidate Recommendation to
           <ul>
             <li>signal to the wider community that it is time to do a final review</li>

--- a/index.html
+++ b/index.html
@@ -2049,7 +2049,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
         Publishing a Candidate Recommendation triggers a Call for Exclusions, per
         <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Exclusion">section 4</a> of the
         <a href="https://www.w3.org/Consortium/Patent-Policy">W3C Patent Policy</a> [<a href="#ref-patentpolicy">PUB33</a>], except if the
-        document is intended to become an <a href="#rec-amended">Amended Recommendation</a> or only contains editorial changes.</p>
+        document is intended to become an <a href="#rec-amended">Amended Recommendation</a> or contains only editorial changes.</p>
       <p>Possible next steps:</p>
       <ul>
         <li>Return to <a href="#revised-wd">Working Draft</a></li>


### PR DESCRIPTION
Clarify restriction. 

A Candidate Recommendation is a document that satisfies the technical requirements from the Working Group or *contains only* substantive corrections if there is no Working Group, and has already received wide review. ...
(instead of "only contains")