### PR TITLE
Allow anticiapted special elections

### DIFF
--- a/index.html
+++ b/index.html
@@ -809,8 +809,12 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
           but no later than the next regularly scheduled election.</li>
         <li>When an elected seat on either the AB or TAG is vacated, the seat is filled at the next regularly scheduled election
           for the group unless the group Chair requests that W3C hold an election before then (for instance,
-          due to the group's workload). The group Chair <em class="rfc2119">should not</em> request an exceptional election
-          if the next regularly scheduled election is fewer than three months away.</li>
+          due to the group's workload). <ul>
+          <li>The group Chair <em class="rfc2119">should not</em> request an exceptional election
+            if the next regularly scheduled election is fewer than three months away.</li>
+          <li>The group Chair <em class="rfc2119">may</em> request an exceptional election,
+            and the election may begin, as soon as a current member gives notice of a resignation, 
+            including a resignation effective as of a given date in the future.</li></ul></li>
       </ul>
 
       <h2 id="Policies">3 General Policies for W3C Groups</h2>
@@ -2974,6 +2978,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
         who as interested individuals and/or with the affiliation(s) listed,
         have contributed to this proposal for a revised Process: </p>
       <p>
+        David Baron (Mozilla),
         Michael Champion (Microsoft),
         Paul Cotton (Microsoft),
         Virginia Fournier (Apple),
@@ -3064,8 +3069,13 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
       <p>This document is based on the <a href="http://www.w3.org/2017/Process-20170301/">1 March 2017 Process</a>.
         <a href="https://github.com/w3/w3process/">Detailed logs of all changes</a> are available.</p>
 
-      <p>No substantive changes have yet been made,
-        compared to the <a href="http://www.w3.org/2017/Process-20170301/">1 March 2017 Process</a>.</p>
+      <p>Changes made since the <a href="http://www.w3.org/2017/Process-20170301/">1 March 2017 Process</a>:</p>
+      
+      <dl>
+       <dt><a href="#AB-TAG-vacated">Section 2.5.3</a></dt>
+        <dd>Clarify that a special election can begin if a candidate resigns as of some future date,
+         rather than waiting for that resignation to take effect.</dd>
+      </dl>
 
     </main>
   </body>


### PR DESCRIPTION
Fix #62
If you someone resigns effective in the future, you can start the
election to replace them.