### PR TITLE
Revert "There is just one vote in elections, which are STV"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2593,14 +2593,16 @@ Superceded is the same as for declaring it Obsolete, below; only the name and ex
         The archive of these comments <em class="rfc2119">must</em> be Member-visible. If, within
         <span class="time-interval">one week</span> of the Team's announcement, 5% or more of the Advisory Committee support the
         appeal request, the Team <em class="rfc2119">must</em> organize an appeal vote asking the Advisory Committee to
-        approve or reject the decision.</p>
+        approve or reject the decision.
+        <!-- Voting procedure to be determined --></p>
 
       <h3 id="ACVotes">7.3 Advisory Committee Votes</h3>
 
       <p>The Advisory Committee votes in <a href="#AB-TAG-elections">elections for seats on the TAG or Advisory Board</a>, and in
         the event of an <a href="#def-w3c-decision">Advisory Committee Appeal</a> achieving the required support to trigger an
-        appeal vote. Whenever the Advisory Committee votes, each Member or group of <a href="#MemberRelated">related Members</a>
-        has one vote.</p>
+        appeal vote.. Whenever the Advisory Committee votes, each Member or group of <a href="#MemberRelated">related Members</a>
+        has one vote. In the case of <a href="#AB-TAG-elections">Advisory Board and TAG elections</a>, "one vote" means
+        "one vote per available seat".</p>
 
       <h2 id="GAEvents">8 Workshops and Symposia</h2>
 


### PR DESCRIPTION
Reverts w3c/w3process#69

Misunderstanding of the meeting (I had thought we would make the change that made the document consistent, and raise the issue to the AC).