### PR TITLE
Fix #33 allow for extended review

### DIFF
--- a/index.html
+++ b/index.html
@@ -1416,7 +1416,12 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
 
         <p>The Director's Call for Review of a substantively modified charter <em class="rfc2119">must</em> highlight
           important changes (e.g., regarding deliverables or resource allocation) and include rationale for the changes.</p>
-
+          
+        <p>In an Advisory Committee review of a charter that continues work on a Working Draft (WD) published under any other Charter,
+         any Advisory Committee Member <em class="rfc2119">may</em> request an "extended review". If this occurs, the Director
+         <em class="rfc2119">must not</em> issue a Call for Participation for the proposed group until at least 60 days
+         after announcing the Call for Review.</p>
+          
         <h4>5.2.4 <dfn id="cfp">Call for Participation in a Working Group or Interest Group</dfn></h4>
 
         <p>After Advisory Committee review of a Working Group or Interest Group charter, the Director
@@ -3132,6 +3137,9 @@ Superceded is the same as for declaring it Obsolete, below; only the name and ex
         <a href="https://www.w3.org/Consortium/cepc/" title="Code of Ethics and Professional Conduct">CEPC</a></dd>
         <dd>The Director can suspend or remove a participant from any Group or activity for failure to meet
         participation criteria.</dd>
+        <dt><a href="#CharterReview">Section 5.2.3</a></dt>
+         <dd>Members can require a 60-day minimum between Call for Review of a Charter that continues work on an existing WD
+         and the Call for Participation for the group.</dd>
         <dt><a href="#revised-cr">Section 6.4.1</a></dt>
         <dd>All changes to Candidate Recommendations need approval.</dd>
         <dt><a href="#Liaisons">Section 9</a></dt>


### PR DESCRIPTION
For modified charters (or taking work from another charter), members can
require a 60-day minimum between AC review starting and Call for
Participation