### PR TITLE
Obsolete dfn: avoid implying market relevance was ever achieved or would be again

### DIFF
--- a/index.html
+++ b/index.html
@@ -1845,10 +1845,10 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
               <dd>Where there is no Working Group chartered to maintain a Recommendation W3C may produce a new
               version which W3C publishes as an Amended version of the Recommendation.</dd>
             <dt id="RecsObs">Obsolete or Superseded Recommendation</dt>
-              <dd>An Obsolete Recommendation is a specification that the W3C believes no longer has enough market relevance
+              <dd>An Obsolete Recommendation is a specification that the W3C has determined lacks sufficient market relevance
                to continue recommending it for implementation, but which does not have fundamental problems
-               that would require it to be Rescinded. It is possible for an Obsolete specification to regain enough market
-               relevance that the W3C decides to restore it to Recommendation status.</dd>
+               that would require it to be Rescinded. If an Obsolete specification gains sufficient market relevance,
+               the W3C may decide to restore it to Recommendation status.</dd>
               <dd>A Superseded Recommendation is a specification that has been replaced by a newer version
                that the W3C recommends for new adoption. An Obsolete or Superseded specification has the same status
                as a W3C Recommendation with regards to W3C Royalty-Free IPR Licenses granted under the Patent Policy.</dd>


### PR DESCRIPTION
Simplify lack of market relevance in Obsolete definition to avoid implying market relevance was ever achieved or would be "re"gained. As proposed https://github.com/w3c/w3process/issues/36#issuecomment-328685098 and "fine by me" @dwsinger https://github.com/w3c/w3process/issues/36#issuecomment-328685601