### PR TITLE
[6.9] "advise against using" is too strong

### DIFF
--- a/index.html
+++ b/index.html
@@ -2481,8 +2481,8 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
       <h3 id="rec-rescind">6.9 Declaring a W3C Recommendation Rescinded, Obsolete or Superseded</h3>
 
       <p>It is possible that W3C decides that implementing a particular Recommendation is no longer recommended.
-        There are three designations for such specifications, chosen depending on how strongly W3C wishes to advise against
-        using the specification.</p>
+        There are three designations for such specifications, chosen depending on the advice W3C wishes to give about
+        further use of the specification.</p>
 
       <p>W3C <em class="rfc2119">may</em> obsolete a Recommendation, for example if the W3C Community decides that
         the Recommendation no longer represents best practices, or is not adopted and is not apparently likely to be adopted.


### PR DESCRIPTION
A specification has many uses, including as a historical reference
document.  W3C might not be "advising against" [any] use, e.g. in the
case of a spec that is "not apparently likely to be adopted"; we may
just be "advising that this specification has not seen implementation
and is therefore obsolete."