### PR TITLE
Don't open ballot at CR

### DIFF
--- a/index.html
+++ b/index.html
@@ -2159,7 +2159,8 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
       <p>The Director:</p>
       <ul>
         <li><em class="rfc2119">must</em> announce the publication of a Proposed Recommendation to the
-          <a href="#AC">Advisory Committee</a>, and</li>
+          <a href="#AC">Advisory Committee</a>, and <em class="rfc2119">must</em> begin an Advisory Committee Review on the question of whether the
+-        specification is appropriate to publish as a W3C Recommendation.</li>
         <li><span><em class="rfc2119">may</em> approve a Proposed Recommendation with minimal implementation experience where
           there is a compelling reason to do so. In such a case, the Director <em class="rfc2119">should</em> explain the
           reasons for that decision.</span></li>

--- a/index.html
+++ b/index.html
@@ -2089,8 +2089,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
           new Candidate Recommendation.</li>
       </ul>
       <p>The Director <em class="rfc2119">must</em> announce the publication of a Candidate Recommendation to other W3C groups
-        and to the public, and <em class="rfc2119">must</em> begin an Advisory Committee Review on the question of whether the
-        specification is appropriate to publish as a W3C Recommendation.</p>
+        and to the public.</p>
 
       <p> A Candidate Recommendation corresponds to a "Last Call Working Draft" as used in the
         <a href="https://www.w3.org/Consortium/Patent-Policy">W3C Patent Policy</a> [<a href="#ref-patentpolicy">PUB33</a>].


### PR DESCRIPTION
Issue #34 
Revert the early ballot open at CR.
Remove ", and <em class="rfc2119">must</em> begin an Advisory Committee Review on the question of whether the specification is appropriate to publish as a W3C Recommendation"