### PR TITLE
make dfn elements linkable

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
     <p>The terms <em class="rfc2119">must</em>, <em class="rfc2119">must not</em>, <em class="rfc2119">should</em>,
       <em class="rfc2119">should not</em>, <em class="rfc2119">required</em>, and <em class="rfc2119">may</em> are used
       in accordance with <a href="https://www.ietf.org/rfc/rfc2119.txt" data-ref="RFC2119">RFC 2119</a>.
-      The term <dfn><em class="rfc2119">not required</em></dfn> is equivalent to the term
+      The term <dfn id="not-required"><em class="rfc2119">not required</em></dfn> is equivalent to the term
       <em class="rfc2119">may</em> as defined in <a href="#ref-RFC2119" data-ref="RFC2119">RFC2119</a>.</p>
 
     <p>Some terms have been capitalized in this document (and in other W3C materials) to indicate that they are entities
@@ -1134,7 +1134,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
 
       <p>When group participants believe that their concerns are not being duly considered by the group, they
         <em class="rfc2119">may</em> ask the <a href="#def-Director">Director</a> (for representatives of a Member organization,
-        via their Advisory Committee representative) to confirm or deny the decision. This is a <dfn>Group Decision Appeal</dfn>.
+        via their Advisory Committee representative) to confirm or deny the decision. This is a <dfn id="wg-decision-appeal">Group Decision Appeal</dfn>.
         The participants <em class="rfc2119">should</em> also make their requests known to the
         <a href="#TeamContact">Team Contact</a>. The Team Contact <em class="rfc2119">must</em> inform the Director when a group
         participant has raised concerns about due process.</p>
@@ -1613,7 +1613,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
 
       <h3 id="rec-advance">6.1 W3C Technical Reports</h3>
 
-      <p>Please note that <dfn>publishing</dfn> as used in this document refers to producing a version which is listed as a
+      <p>Please note that <dfn id="publishing">Publish a Working Draft</dfn> as used in this document refers to producing a version which is listed as a
         W3C Technical Report on its <a href="https://www.w3.org/TR/" data-ref="PUB11">Technical Reports page https://www.w3.org/TR</a>.</p>
 
       <p>This chapter describes the formal requirements for publishing and maintaining a W3C Recommendation or Note.</p>
@@ -1980,7 +1980,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
 
       <h4 id="transition-reqs">6.2.2 Advancement on the Recommendation Track</h4>
 
-      <p>For <em>all</em> <dfn>Transition Requests</dfn>, to advance a specification to a new maturity level other than Note,
+      <p>For <em>all</em> <dfn id="transition-requests">Transition Requests</dfn>, to advance a specification to a new maturity level other than Note,
         the Working Group:</p>
 
       <ul>
@@ -2050,7 +2050,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
       <p>Implementation experience is required to show that a specification is sufficiently clear, complete, and relevant to market
         needs, to ensure that independent interoperable implementations of each feature of the specification will be realized.
         While no exhaustive list of requirements is provided here, when assessing that there is
-        <dfn>adequate implementation experience</dfn> the Director will consider (though not be limited to):</p>
+        <dfn id="adequate-implementation">adequate implementation experience</dfn> the Director will consider (though not be limited to):</p>
       <ul>
         <li>is each feature of the current specification implemented, and how is this demonstrated?</li>
         <li>are there independent interoperable implementations of the current specification?</li>
@@ -2956,7 +2956,7 @@ Superseded is the same as for declaring it Obsolete, below; only the name and ex
             <li>If <a href="#SubmissionYes">acknowledged</a>, the Team <em class="rfc2119">must</em> publish the Member Submission
               at the public W3C Web site, in addition to Team comments about the Member Submission.</li>
             <li>If <a href="#SubmissionNo">rejected</a>, the Submitter(s) <em class="rfc2119">may</em> initiate a
-              <dfn>Submission Appeal</dfn> to either the <a href="#TAG">TAG</a> or the <a href="#AB">Advisory Board</a>.</li>
+              <dfn id="submission-appeal">Submission Appeal</dfn> to either the <a href="#TAG">TAG</a> or the <a href="#AB">Advisory Board</a>.</li>
           </ul>
         </li>
       </ol>


### PR DESCRIPTION
A few definitions had crept in that were not linkable. This fixes that.