### PR TITLE
Avoid some redirects and minor nitpicks, including in the changelog

### DIFF
--- a/index.html
+++ b/index.html
@@ -3430,7 +3430,7 @@ Superseded is the same as for declaring it Obsolete, below; only the name and ex
         <dt><a href="#revised-rec">Section 6.7.2</a></dt>
 	<dd>W3C can produce an <a href="#rec-amended">Amended Recommendation</a>
         to update a Recommendation, without adding new features, parallel to the way a Working Group produces an Edited Recommendation.</dd>
-        <dt><a href="##rec-rescind">Section 6.9</a></dt>
+        <dt><a href="#rec-rescind">Section 6.9</a></dt>
 	<dd>A Recommendation can be declared Superseded.</dd>
 	<dt><a href="#ACAppeal">Section 7.2</a></dt>
 	<dd>Clarify that in the event of an Advisory Committee appeal, a Director's decision can be overtuned by more votes for than against</dd>

--- a/index.html
+++ b/index.html
@@ -1258,7 +1258,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
           <a href="#member-rep">Member representative</a>, a <a href="#Team">Team representative</a>, or an
           <a href="#invited-expert-wg">Invited Expert</a> (invited by the Director). The requirements of this document that
           apply to those types of participants apply to Chairs as well. The
-          <a href="/Guide/chair-roles">role of the Chair</a> is described in the
+          <a href="https://www.w3.org/Guide/chair-roles">role of the Chair</a> is described in the
           <a href="https://www.w3.org/Guide/" data-ref="PUB37">Art of Consensus</a>.</p>
         <p>Each group <em class="rfc2119">must</em> have a <dfn id="TeamContact">Team Contact</dfn>, who acts as the interface
           between the Chair, group participants, and the rest of the Team. The
@@ -1977,7 +1977,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
         participant, per <a href="#group-participation">section 5.2.1</a> in the Group responsible for the document(s) they are
         editing. </p>
       <p>The Team is <em class="rfc2119">not required</em> to publish a Technical Report that does not conform to the Team's
-        <a href="https://www.w3.org/Guide/pubrules" data-ref="PUB31">Publication Rules</a>(e.g., for
+        <a href="https://www.w3.org/pubrules/" data-ref="PUB31">Publication Rules</a>(e.g., for
         <span id="DocumentName">naming</span>, status information, style, and
         <span id="document-copyright">copyright requirements</span>). These rules are subject to change by the Team from
         time to time. The Team <em class="rfc2119">must</em> inform group Chairs and the Advisory Committee of any changes to
@@ -3049,7 +3049,7 @@ Superseded is the same as for declaring it Obsolete, below; only the name and ex
         <li>Complete electronic copies of any documents submitted for consideration (e.g., a technical specification, a position
           paper, etc.) If the Submission request is acknowledged, these documents will be published by W3C and therefore
           <em class="rfc2119">must</em> satisfy the Communication Team's
-          <a href="https://www.w3.org/Guide/pubrules" data-ref="PUB31">Publication Rules</a>.
+          <a href="https://www.w3.org/pubrules/" data-ref="PUB31">Publication Rules</a>.
           Submitters <em class="rfc2119">may</em> hold the copyright for the material contained in these documents, but when
           published by W3C, these documents <em class="rfc2119">must</em> be subject to the provisions of the
           <a href="https://www.w3.org/Consortium/Legal/copyright-documents" data-ref="PUB18">W3C Document License</a>.</li>
@@ -3074,7 +3074,7 @@ Superseded is the same as for declaring it Obsolete, below; only the name and ex
 
       <p>Although they are not technical reports, the documents in a Member Submission <em class="rfc2119">must</em> fulfil the
         requirements established by the Team, including the Team's
-        <a href="https://www.w3.org/Guide/pubrules">Publication Rules</a>.</p>
+        <a href="https://www.w3.org/pubrules/">Publication Rules</a>.</p>
 
       <p>The Team sends a <a id="validation-notice">validation notice</a> to the Submitter(s) once the Team has reviewed a
         Submission request and judged it complete and correct.</p>
@@ -3204,7 +3204,7 @@ Superseded is the same as for declaring it Obsolete, below; only the name and ex
         <dt id="ref-ab-home">[PUB30]</dt>
          <dd><cite><a href="https://www.w3.org/2002/ab/">The Advisory Board home page</a></cite></dd>
         <dt id="ref-pubrules">[PUB31]</dt>
-         <dd><cite><a href="https://www.w3.org/Guide/pubrules">Publication Rules</a></cite></dd>
+         <dd><cite><a href="https://www.w3.org/pubrules/">Publication Rules</a></cite></dd>
         <dt id="ref-fellows">[PUB32]</dt>
          <dd><cite><a href="https://www.w3.org/Consortium/Recruitment/Fellows">W3C Fellows Program</a></cite></dd>
         <dt id="ref-patentpolicy">[PUB33]</dt>
@@ -3233,7 +3233,7 @@ Superseded is the same as for declaring it Obsolete, below; only the name and ex
         <dt id="ref-current-ac">[MEM1]</dt>
          <dd><cite><a href="https://www.w3.org/Member/ACList">Current Advisory Committee representatives</a></cite></dd>
         <dt id="ref-mailing-lists">[MEM2]</dt>
-         <dd><cite><a href="https://www.w3.org/Member/Mail/">Group mailing lists</a></cite></dd>
+         <dd><cite><a href="https://www.w3.org/Member/Groups">Group mailing lists</a></cite></dd>
         <dt id="oldref-mem-calendar">[MEM3]</dt>
          <dd>The Member-only <cite><a href="https://www.w3.org/Member/Eventscal">calendar of all scheduled official W3C events</a></cite>
          is no longer maintained. The information is now maintained in the <a href="#ref-calendar" data-ref="PUB36">public calendar</a></dd>
@@ -3405,7 +3405,7 @@ Superseded is the same as for declaring it Obsolete, below; only the name and ex
        <dt><a href="#tag-participation">Section 2.4.1</a></dt>
         <dd>Tim Berners-Lee is a Life Member of the TAG.</dd>
         <dd>The TAG chair <em class="rfc2119">must</em> be one of the participants</dd>
-        <dd>The TAG has Six AC-elected members instead of 5</dd>
+        <dd>The TAG has 6 AC-elected members instead of 5</dd>
         <dd>The TAG has a team contact</dd>
        <dt><a href="#AB-TAG-participation">Section 2.5</a></dt>
         <dd>Seats on the AB or TAG cannot be delegated to a proxy</dd>
@@ -3415,7 +3415,7 @@ Superseded is the same as for declaring it Obsolete, below; only the name and ex
         <dd>Clarify that a special election can begin if a candidate resigns as of some future date,
          rather than waiting for that resignation to take effect.</dd>
        <dt><a href="#ParticipationCriteria">Section 3.1</a></dt>
-        <dd>Participants in W3C activity are required to abide by the terms and spirit of the 
+        <dd>Participants in W3C activity are explicitly required to abide by the terms and spirit of the 
         <a href="https://www.w3.org/Consortium/cepc/" title="Code of Ethics and Professional Conduct">CEPC</a></dd>
         <dd>The Director can suspend or remove a participant from any Group or activity for failure to meet
         participation criteria.</dd>
@@ -3429,11 +3429,11 @@ Superseded is the same as for declaring it Obsolete, below; only the name and ex
         <dd>All changes to Candidate Recommendations need Director's approval.</dd>
         <dt><a href="#revised-rec">Section 6.7.2</a></dt>
 	<dd>W3C can produce an <a href="#rec-amended">Amended Recommendation</a>
-        to update a Recommendation, without adding new features analogous to the way a Working Group produces an Edited Recommendation.</dd>
-        <dt><a href="#rescinded-rec">Section 6.9</a></dt>
-	<dd>A Recommendation can be declared superseded as well as obsolete.</dd>
+        to update a Recommendation, without adding new features, parallel to the way a Working Group produces an Edited Recommendation.</dd>
+        <dt><a href="##rec-rescind">Section 6.9</a></dt>
+	<dd>A Recommendation can be declared Superseded.</dd>
 	<dt><a href="#ACAppeal">Section 7.2</a></dt>
-	<dd>Clarify that in the event of an Advisory Committee appeal,a Director's decision can be overtuned by more votes for than against</dd>
+	<dd>Clarify that in the event of an Advisory Committee appeal, a Director's decision can be overtuned by more votes for than against</dd>
         <dt><a href="#Liaisons">Section 9</a></dt>
         <dd>Definition of MoU and conditions for approval.</dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -3420,8 +3420,9 @@ Superseded is the same as for declaring it Obsolete, below; only the name and ex
         <dd>The Director can suspend or remove a participant from any Group or activity for failure to meet
         participation criteria.</dd>
        <dt><a href="#CharterReview">Section 5.2.3</a></dt>
-         <dd>Members can require a 60-day minimum between Call for Review of a Charter that continues work on an existing WD
-         and the Call for Participation for the group.</dd>
+         <dd>An AC member may request at least 60 days to review any new or substantively modified working group charter,
+           with such review period occurring between the Call for Review and the Call for Participation.
+         </dd>
         <dt><a href="#WGCharter">Section 5.2.6</a></dt>
          <dd>Charters <em class="rfc2119">must</em> include documentation of any voting procedures additional to those defined 
          in <a href="#Votes">Section 3.4 Voting</a>.</dd>
@@ -3429,7 +3430,7 @@ Superseded is the same as for declaring it Obsolete, below; only the name and ex
         <dd>All changes to Candidate Recommendations need Director's approval.</dd>
         <dt><a href="#revised-rec">Section 6.7.2</a></dt>
 	<dd>W3C can produce an <a href="#rec-amended">Amended Recommendation</a>
-        to update a Recommendation, without adding new features, parallel to the way a Working Group produces an Edited Recommendation.</dd>
+        to update a Recommendation, without adding new features, similar to the way a Working Group produces an Edited Recommendation.</dd>
         <dt><a href="#rec-rescind">Section 6.9</a></dt>
 	<dd>A Recommendation can be declared Superseded.</dd>
 	<dt><a href="#ACAppeal">Section 7.2</a></dt>


### PR DESCRIPTION
Nothing like publishing a document to find additional nitpicks. This aligns with the changes done in
 https://www.w3.org/2018/Process-20180201/