### PR TITLE
Expand and clarify the 'personal capacity' aspect of AB/TAG participation

### DIFF
--- a/index.html
+++ b/index.html
@@ -731,13 +731,9 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
         are expected to participate regularly and fully. Advisory Board and TAG participants <em class="rfc2119">should</em>
         attend <a href="#ACMeetings">Advisory Committee meetings</a>.</p>
 
-      <p>Individuals elected to the Advisory Board act in their personal capacity on the Board, to serve the needs of the
+      <p>Individuals elected or appointed to the Advisory Board or TAG act in their personal capacity, to serve the needs of the
 	W3C membership as a whole, and the Web community. Whether they are Member representatives or Invited Experts, their
-	activities in those roles are separate and distinct from their activities on the Advisory Board.</p>
-
-      <p>Individuals elected or appointed to the TAG act in their personal capacity in the TAG, to serve the needs of the
-	W3C membership as a whole, and the Web community. If they are Member representatives or Invited Experts, their
-	activities in those roles are separate and distinct from their activities in the TAG.</p>
+	activities in those roles are separate and distinct from their activities on the Advisory Board or TAG.</p>
 
       <p>An individual participates on the Advisory Board or TAG from the moment the individual's term begins
         until the seat is <a href="#AB-TAG-vacated">vacated</a> (e.g. because the term ends). Although Advisory Board and TAG participants do not advocate for

--- a/index.html
+++ b/index.html
@@ -731,17 +731,14 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
         are expected to participate regularly and fully. Advisory Board and TAG participants <em class="rfc2119">should</em>
         attend <a href="#ACMeetings">Advisory Committee meetings</a>.</p>
 
-      <p>Individuals elected to the Advisory Board act in their personal capacity on the Board, in spite
-	      of being Member representatives, and in spite of any parallel involvement in other W3C activities as Member
-	      representatives.</p>
-	    
-      <p>Individuals who are Member representatives and are elected or appointed to the TAG act in their personal capacity
-	      on the TAG, in spite of being Member representatives, and in spite of any parallel involvement in other W3C
-	      activities as Member representatives.</p>
-	    
-      <p>Individuals who are not Member representatives and are appointed to the TAG act in their personal capacity as Invited
-	      Experts on the TAG.</p>
-	    
+      <p>Individuals elected to the Advisory Board act in their personal capacity on the Board, to serve the needs of the
+	W3C membership as a whole, and the Web community. Whether they are Member representatives or Invited Experts, their
+	activities in those roles are separate and distinct from their activities on the Advisory Board.</p>
+
+      <p>Individuals elected or appointed to the TAG act in their personal capacity in the TAG, to serve the needs of the
+	W3C membership as a whole, and the Web community. If they are Member representatives or Invited Experts, their
+	activities in those roles are separate and distinct from their activities in the TAG.</p>
+
       <p>An individual participates on the Advisory Board or TAG from the moment the individual's term begins
         until the seat is <a href="#AB-TAG-vacated">vacated</a> (e.g. because the term ends). Although Advisory Board and TAG participants do not advocate for
         the commercial interests of their employers, their participation does carry the responsibilities associated with

--- a/index.html
+++ b/index.html
@@ -731,6 +731,17 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
         are expected to participate regularly and fully. Advisory Board and TAG participants <em class="rfc2119">should</em>
         attend <a href="#ACMeetings">Advisory Committee meetings</a>.</p>
 
+      <p>Individuals elected to the Advisory Board act in their personal capacity on the Board, in spite
+	      of being Member representatives, and in spite of any parallel involvement in other W3C activities as Member
+	      representatives.</p>
+	    
+      <p>Individuals who are Member representatives and are elected or appointed to the TAG act in their personal capacity
+	      on the TAG, in spite of being Member representatives, and in spite of any parallel involvement in other W3C
+	      activities as Member representatives.</p>
+	    
+      <p>Individuals who are not Member representatives and are appointed to the TAG act in their personal capacity as Invited
+	      Experts on the TAG.</p>
+	    
       <p>An individual participates on the Advisory Board or TAG from the moment the individual's term begins
         until the seat is <a href="#AB-TAG-vacated">vacated</a> (e.g. because the term ends). Although Advisory Board and TAG participants do not advocate for
         the commercial interests of their employers, their participation does carry the responsibilities associated with
@@ -740,7 +751,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
         <a href="https://www.w3.org/Consortium/Patent-Policy" data-ref="PUB33">W3C Patent Policy</a>,
         and the claim exclusion process of <a href="https://www.w3.org/Consortium/Patent-Policy#sec-Exclusion">section 4</a>.</p>
 
-      <p>Participation in the TAG or AB other than as Chair or Team Contact is in a personal capacity,
+      <p>Participation in the TAG or AB is afforded to the specific individuals elected or appointed to those positions,
        and a participant's seat <em class="rfc2119">must not</em> be delegated to any other person.</p>
       
       <h4 id="AB-TAG-constraints">2.5.1 Advisory Board and Technical Architecture Group Participation Constraints</h4>


### PR DESCRIPTION
This change separates the 'personal capacity' statements in the AB/TAG Participation section from the statement about delegation of seats, and also spells out the three scenarios for AB/TAG participation via election and appointment and how 'personal capacity' differs from the stated affiliations of participants.