### PR TITLE
editorial clarification

### DIFF
--- a/index.html
+++ b/index.html
@@ -2122,8 +2122,8 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
 
       <p>When a contributor who is not a Working Group participant offers a change in class 3 or 4 (as described in <a href="#correction-classes">6.2.5</a>)
       the Team <em class=rfc2119>must</em> request from the contributor a recorded royalty-free patent commitment; for a change in class 4, the Team <em class=rfc2119>must</em> secure such commitment.
-	Such commitment <em class=rfc2119>should</em> cover, at a minimum, all the contributor’s Essential Claims in the contribution, and
-        those that become Essential Claims as a result of incorporating the contribution into the draft
+	Such commitment <em class=rfc2119>should</em> cover, at a minimum, all the contributor’s Essential Claims both in the contribution, and
+         that become Essential Claims as a result of incorporating the contribution into the draft
         that existed at the time of the contribution, on the terms specified in section 5 (W3C Royalty-Free (RF) Licensing
         Requirements) of the W3C Patent Policy.</p>
 


### PR DESCRIPTION
remove an extraneous "both" to make the language re Essential Claims make sense