### PR TITLE
Clarification on Member submissions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3073,10 +3073,9 @@ Superseded is the same as for declaring it Obsolete, below; only the name and ex
       <p><strong>Note:</strong> To avoid confusion about the Member Submission process, please note that:</p>
 
       <ul>
-        <li>Documents in a Member Submission are developed outside of W3C. These documents are <strong>not</strong> part of the
+        <li>Documents in a Member Submission are developed outside of the W3C
           <a href="#Reports">technical report development process</a> (and therefore are not included in the
-          <a href="https://www.w3.org/TR/">index of W3C technical reports</a>). Members wishing to have documents developed outside
-          of W3C published by W3C <em class="rfc2119">must</em> follow the Member Submission process.</li>
+          <a href="https://www.w3.org/TR/">index of W3C technical reports</a>).</li>
         <li>The Submission process is <strong>not</strong> a means by which Members ask for "ratification" of these documents as
           <a href="#RecsW3C">W3C Recommendations</a>.</li>
         <li>There is no requirement or guarantee that technology which is part of an acknowledged Submission request will receive


### PR DESCRIPTION
Stop claiming that Member submissions is the only allowable way to get
documents developed outside the process into W3C. CGs exist too. They
don't need to be mentioned here, but the previous phrasing appeared to
rule them out, which was not appropriate.

Closes #169