### PR TITLE
Revert to an earlier phrasing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1638,7 +1638,7 @@ Advisory Board, TAG, Working Group, Interest Group, Workshop, charter, Working D
 
       <h3 id="rec-advance">6.1 W3C Technical Reports</h3>
 
-      <p>Please note that <dfn id="publishing">Publishing a Working Draft</dfn> as used in this document refers to producing a version which is listed as a
+      <p>Please note that <dfn id="publishing">Publishing</dfn> as used in this document refers to producing a version which is listed as a
         W3C Technical Report on its <a href="https://www.w3.org/TR/" data-ref="PUB11">Technical Reports page https://www.w3.org/TR</a>.</p>
 
       <p>This chapter describes the formal requirements for publishing and maintaining a W3C Recommendation or Note.</p>


### PR DESCRIPTION
The new phrasing is narrower than the original one, and excludes cases
that shouldn't be excluded.