### PR TITLE
[director-free] Gratuitous mentions of the Director

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -258,7 +258,7 @@ Members</h3>
 					reviews plans for W3C at each <a href="#ACMeetings">Advisory Committee meeting</a>;
 
 				<li>
-					reviews formal proposals from the W3C Director:
+					reviews formal proposals from the W3C:
 					<a href="#CharterReview">Charter Proposals</a>,
 					<a href="#RecsPR">Proposed Recommendations</a>,
 					and <a href="#GAProcess">Proposed Process Documents</a>.
@@ -1273,7 +1273,7 @@ Recording and Reporting Formal Objections</h4>
 	and propose changes that would remove the [=Formal Objection=];
 	these proposals <em class="rfc2119">may</em> be vague or incomplete.
 	[=Formal Objections=] that do not provide substantive arguments
-	or rationale are unlikely to receive serious consideration by the Director.
+	or rationale are unlikely to receive serious consideration.
 
 	A record of each [=Formal Objection=] <em class="rfc2119">must</em> be <a href="#confidentiality-change">publicly available</a>.
 	A Call for Review (of a document) to the Advisory Committee <em class="rfc2119">must</em> identify any [=Formal Objections=].
@@ -1472,7 +1472,7 @@ Dissemination Policies</h2>
 
 	<ul>
 		<li>
-			<a href="#Reports">W3C technical reports</a> whose publication has been approved by the Director.
+			<a href="#Reports">W3C technical reports</a> whose publication has been approved.
 			Per the Membership Agreement,
 			W3C technical reports (and software) are available free of charge to the general public;
 			(refer to the <a href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document License</a> [[DOC-LICENSE]]).
@@ -1644,7 +1644,7 @@ Requirements for All Working and Interest Groups</h3>
 	The Director appoints (and re-appoints) Chairs for all groups.
 	The Chair is a <a href="#member-rep">Member representative</a>,
 	a <a href="#Team">Team representative</a>,
-	or an <a href="#invited-expert-wg">Invited Expert</a>
+	or an <a href="#invited-expert-wg">Invited Expert</a>,
 	(invited by the Director).
 	The requirements of this document that apply to those types of participants apply to Chairs as well.
 	The <a href="https://www.w3.org/Guide/chair/role.html">role of the Chair</a> [[CHAIR]] is described
@@ -1929,7 +1929,7 @@ Team Representative in a Working Group</h5>
 	</ul>
 
 	The Team participates in a Working Group
-	from the moment the Director announces the creation of the group
+	from the moment the creation of the group is announced
 	until the group closes.
 
 <h5 id="team-rep-ig">
@@ -1972,7 +1972,7 @@ Advisory Committee Review of a Working Group or Interest Group Charter</h4>
 	and to <a href="#wgparticipant"> participants in the Working</a> or <a href="#igparticipant">in the Interest Group</a>,
 	and a rationale must be provided.
 
-	The Director's Call for Review of a substantively modified charter
+	The Call for Review of a substantively modified charter
 	<em class="rfc2119">must</em> highlight important changes
 	(e.g., regarding deliverables or resource allocation)
 	and include rationale for the changes.
@@ -1994,7 +1994,7 @@ Call for Participation in a Working Group or Interest Group</h4>
 	After [=Advisory Committee review=] of a [=Working Group=] or [=Interest Group=] [=charter=],
 	the Director <em class="rfc2119">may</em> issue a Call for Participation to the Advisory Committee.
 	Charters <em class="rfc2119">may</em> be amended based on review comments
-	before the Director issues a Call for Participation.
+	before the Call for Participation.
 
 	For a new group, this announcement officially creates the group.
 	The announcement <em class="rfc2119">must</em> include a reference to the <a href="#WGCharter">charter</a>,
@@ -2008,7 +2008,7 @@ Call for Participation in a Working Group or Interest Group</h4>
 
 	Advisory Committee representatives <em class="rfc2119">may</em> initiate
 	an <a href="#ACAppeal">Advisory Committee Appeal</a>
-	against a Director's decision to create
+	against the decision to create
 	or substantially modify
 	a Working Group or Interest Group charter.
 
@@ -2924,12 +2924,12 @@ Advancement on the Recommendation Track</h4>
 	For later stages,
 	especially transition to [=Candidate Recommendation|Candidate=] or [=Proposed Recommendation=],
 	there is usually a formal review meeting
-	to ensure the requirements have been met before [=Director=]'s approval is given.
+	to ensure the requirements have been met before approval is given.
 
 	[=Transition Requests=] to [=First Public Working Draft=]
 	or [=Candidate Recommendation=]
 	will not normally be approved
-	while a [=Working Group=]'s [=charter=] is undergoing or awaiting a [=Director=]'s decision
+	while a [=Working Group=]'s [=charter=] is undergoing or awaiting a decision
 	on an [=Advisory Committee Review=].</p>
 
 <h4 id="update-reqs">
@@ -3626,7 +3626,7 @@ Abandoning an Unfinished Technical Report</h5>
 	to abandon work on the report,
 	or the [=Director=] required the [=Working Group=]
 	to discontinue work on the technical report before completion.
-	If the [=Director=] <a href="#GeneralTermination">closes a Working Group</a>
+	If a [=Working Group=] is made to <a href="#GeneralTermination">close</a>,
 	W3C <em class="rfc2119">must</em> [=publish=] any unfinished [=technical report=]
 	on the Recommendation track as [=Working Group Notes=].
 
@@ -3748,7 +3748,7 @@ Process for Rescinding, Obsoleting, Superseding a Recommendation</h5>
 		<li>
 			specify the deadline for review comments,
 			which <em class="rfc2119">must</em> be at least 28 days
-			after the [=Director=]'s announcement
+			after the announcement
 	</ul>
 
 	and <em class="rfc2119">should</em>
@@ -3948,7 +3948,7 @@ After the Review Period</h4>
 		<li>
 			The proposal is approved,
 			possibly with [=substantive changes=] integrated.
-			In this case the Director's announcement <em class="rfc2119">must</em> include rationale
+			In this case the announcement <em class="rfc2119">must</em> include rationale
 			for the decision to advance the document despite the proposal for a substantive change.
 
 		<li>The proposal is returned for additional work,
@@ -3966,7 +3966,7 @@ After the Review Period</h4>
 	gathered during the review.
 	The [=Advisory Committee=] <em class="rfc2119">should not</em> expect an announcement
 	sooner than <span class="time-interval">two weeks</span> after the end of a review period.
-	If, after <span class="time-interval">three weeks</span>, the Director has not announced the outcome,
+	If, after <span class="time-interval">three weeks</span>, the outcome has not been announced,
 	the [=Director=] <em class="rfc2119">should</em> provide the [=Advisory Committee=] with an update.
 
 <h3 id="ACAppeal">

--- a/index.bs
+++ b/index.bs
@@ -171,7 +171,7 @@ Introduction</h2>
 		<li>
 			When there is enough interest in a topic
 			(e.g., after a successful Workshop and/or discussion on an <a href="#ACCommunication">Advisory Committee mailing list</a>),
-			the Director announces the development of a proposal
+			the [=Team=] announces the development of a proposal
 			for one or more new <a href="#WGCharterDevelopment">Interest Group or Working Group charters</a>,
 			depending on the breadth of the topic of interest.
 			W3C Members <a href="#CharterReview">review</a> the proposed charters.
@@ -785,7 +785,7 @@ Advisory Board and Technical Architecture Group Elections</h4>
 	and operational information such as how to nominate a candidate.
 	The [=Team=] <em class="rfc2119">may</em> modify the tabulation system after the Call for Nominations
 	but <em class="rfc2119">must</em> stabilize it no later than the Call for Votes.
-	The [=Director=] <em class="rfc2119">should</em> announce appointments
+	The [=Team=] <em class="rfc2119">should</em> announce appointments
 	no later than the start of a nomination period as part of the Call for Nominations.
 
 	In the case of regularly scheduled elections of the [=TAG=],
@@ -2603,7 +2603,7 @@ The W3C Recommendation Track</h3>
 	requiring a [=Working Group=] to conduct further work,
 	and <em class="rfc2119">may</em> require
 	the specification to return to a lower <a href="#maturity-levels">maturity level</a>.
-	The Director <em class="rfc2119">must</em> inform the <a href="#AC">Advisory Committee</a>
+	The [=Team=] <em class="rfc2119">must</em> inform the <a href="#AC">Advisory Committee</a>
 	and [=Working Group=] [=Chairs=] when a [=Working Group=]'s request
 	for a specification to advance in maturity level is declined
 	and the specification is returned to a [=Working Group=] for further work.
@@ -2991,7 +2991,7 @@ Updating Mature Publications on the Recommendation Track</h4>
 	Note: [=Update request=] approval is expected to be fairly simple
 	compared to getting approval for a [=transition request=].
 
-	The [=Director=] <em class="rfc2119">must</em> announce the publication
+	The [=Team=] <em class="rfc2119">must</em> announce the publication
 	of the revised specification
 	to other W3C groups and the Public.
 
@@ -3083,7 +3083,7 @@ Publishing a First Public Working Draft</h4>
 	To publish the [=First Public Working Draft=] of a document,
 	a [=Working Group=] <em class="rfc2119">must</em> meet the applicable <a href="#transition-reqs">requirements for advancement</a>.
 
-	The [=Director=] <em class="rfc2119">must</em> announce
+	The [=Team=] <em class="rfc2119">must</em> announce
 	the publication of a [=First Public Working Draft=]
 	to other W3C groups and to the public.
 
@@ -3177,7 +3177,7 @@ Transitioning to Candidate Recommendation</h4>
 	The first Candidate Recommendation publication
 	after approval of a [=Transition Request=]
 	is always a [=Candidate Recommendation Snapshot=].
-	The [=Director=] <em class="rfc2119">must</em> announce
+	The [=Team=] <em class="rfc2119">must</em> announce
 	the publication of the [=Candidate Recommendation Snapshot=]
 	to other W3C groups
 	and to the public.
@@ -3222,7 +3222,7 @@ Publishing a [=Candidate Recommendation Snapshot=]</h5>
 			without a requirement to publish a new [=Candidate Recommendation=].
 	</ul>
 
-	The [=Director=] <em class="rfc2119">must</em> announce
+	The [=Team=] <em class="rfc2119">must</em> announce
 	the publication of a revised [=Candidate Recommendation Snapshot=]
 	to other W3C groups
 	and to the public.
@@ -3430,7 +3430,7 @@ Transitioning to W3C Recommendation</h4>
 			of the [=W3C decision=]
 
 		<li>
-			The [=Director=] <em class="rfc2119">must</em> announce the publication of a [=W3C Recommendation=]
+			The [=Team=] <em class="rfc2119">must</em> announce the publication of a [=W3C Recommendation=]
 			to <a href="#AC">Advisory Committee</a>,
 			other W3C groups
 			and to the public.
@@ -3709,7 +3709,7 @@ Process for Rescinding, Obsoleting, Superseding a Recommendation</h5>
 			5% of the members of the Advisory Committee
 	</ul>
 
-	<p id="proposed-rescinded-rec">The [=Director=] <em class="rfc2119">must</em> then
+	<p id="proposed-rescinded-rec">The [=Team=] <em class="rfc2119">must</em> then
 	submit the request to the <a href="#AC">Advisory Committee</a> for review.
 	For any [=Advisory Committee review=] of a proposal to
 	rescind,
@@ -4374,7 +4374,7 @@ Team Rights and Obligations</h3>
 <h3 id="SubmissionYes">
 Acknowledgment of a Submission Request</h3>
 
-	The [=Director=] <a href="#SubmissionYes">acknowledges</a> a Submission request
+	The [=Team=] <a href="#SubmissionYes">acknowledges</a> a Submission request
 	by sending an announcement to the [=Advisory Committee=].
 	Though the announcement <em class="rfc2119">may</em> be made at any time,
 	the [=Submitter=](s) can expect an announcement between <span class="time-interval">four to six weeks</span>


### PR DESCRIPTION
This pull request removes a number of gratuitous / decorative / redundant mentions of the Director. It changes nothing about the decision power of the Director, instead it focuses on two things (in separate commits):
* Redundant mentions of the Director,  such as things like “the Director’s decision to FOO” when FOO is already defined to be something only the Director can decide.
* Cases where the team must announce something and where no decision is involved. In such cases claiming that the announcement is made in the name of the Director isn't very helpful. Since the Team does these announcements in practice, just replace “the Director must announce…” by “the Team must announce…”.