### PR TITLE
Remove Team Submissions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -539,23 +539,6 @@ The W3C Team</h3>
 	Within W3C, the Host institutions are governed by hosting agreements;
 	the [=Hosts=] themselves are not W3C Members.
 
-<h4 id="TeamSubmission">
-Team Submissions</h4>
-
-	Team members <em class="rfc2119">may</em> request that the Director publish information at the W3C Web site.
-	At the Director's discretion,
-	these documents are published as “Team Submissions”.
-	These documents are analogous to <a href="#Submission">Member Submissions</a>
-	(e.g., in <a href="#SubmissionScope">expected scope</a>).
-	However, there is no additional Team comment.
-	The <a href="#DocumentStatus">document status section</a> of a Team Submission
-	<em class="rfc2119">must</em> indicate the level of Team consensus about the published material.
-
-	Team Submissions are <strong>not</strong> part of the <a href="#Reports">technical report development process</a>.
-
-	The list of <a href="https://www.w3.org/TeamSubmission/">published Team Submissions</a> [[TEAM-SUBMISSION]]
-	is available at the W3C Web site.
-
 <h3 id="AB">
 Advisory Board (AB)</h3>
 
@@ -4865,11 +4848,6 @@ and the <a href="https://www.w3.org/2018/Process-20180201/">1 February 2018 Proc
 	"MISSION": {
 		"href": "https://www.w3.org/Consortium/mission",
 		"title": "The W3C Mission statement",
-		"publisher": "W3C"
-	},
-	"TEAM-SUBMISSION": {
-		"href": "https://www.w3.org/TeamSubmission/",
-		"title": "The list of published Team Submissions",
 		"publisher": "W3C"
 	},
 	"COLLABORATORS-AGREEMENT": {


### PR DESCRIPTION
This part of the process is no longer in use, and other venues exist for
the Team to publish information. Removing it to simplify the Process and
reduce the maintenance workload.

Closes #246