### PR TITLE
Remove reference to stale document

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -322,7 +322,6 @@ Rights of Members</h4>
 	and repeated attempts to address these violations have not resolved the situation,
 	the [=Director=] <em class="rfc2119">may</em> take disciplinary action.
 	Arbitration in the case of further disagreement is governed by paragraph 19 of the Membership Agreement [[MEMBER-AGREEMENT]].
-	Refer to the <a href="https://www.w3.org/2002/09/discipline">Guidelines for Disciplinary Action</a> [[DISCIPLINARY-GL]].
 
 <h4 id="RelatedAndConsortiumMembers">
 Member Consortia and Related Members</h4>
@@ -4998,11 +4997,6 @@ and the <a href="https://www.w3.org/2018/Process-20180201/">1 February 2018 Proc
 	"MEMBER-SUB": {
 		"href": "https://www.w3.org/2000/09/submission",
 		"title": "How to send a Submission request",
-		"publisher": "W3C"
-	},
-	"DISCIPLINARY-GL": {
-		"href": "https://www.w3.org/2002/09/discipline",
-		"title": "Guidelines for Disciplinary Action",
 		"publisher": "W3C"
 	},
 	"ELECTION-HOWTO": {


### PR DESCRIPTION
Section 2.1.1 includes this:

> Refer to the [Guidelines for Disciplinary Action](https://www.w3.org/2002/09/discipline).

This links to a document that is not publicly viewable. We briefly discussed in the AB whether it should be made public, but the conclusion is that while there's nothing secret there, it is too outdated to be useful.

This pull request therefore proposes to remove references to it.

If we eventually come around to make an up to date version of it, that could be added back to the process, but until then, this is just cruft.