### PR TITLE
TAG and AB resignations don't involve the AC-Rep

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -910,7 +910,7 @@ Advisory Board and Technical Architecture Group Vacated Seats</h4>
 
 	<ul>
 		<li>
-			the participant <a href="#resignation">resigns</a>, or
+			the participant resigns, or
 
 		<li>
 			an Advisory Board or TAG participant changes affiliations


### PR DESCRIPTION
Linking the word "resigns" to the section about WG resignations suggested
that maybe it did, but that doesn't make a whole lot of sense,
so rely on the plain English meaning of the word "resign" instead.

Closes #242