### PR TITLE
Add subsection headings to the section about REC revisions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3544,11 +3544,17 @@ Errata Management</h4>
 <h4 id="revised-rec">
 Revising a Recommendation</h4>
 
+<h5 id="revised-rec-markup">
+Revising a Recommendation: Markup Changes</h5>
+
 	A [=Working group=] <em class="rfc2119">may</em> request republication of a [=Recommendation=],
 	or if there is no [=Working Group=] chartered to maintain a [=Recommendation=]
 	W3C <em class="rfc2119">may</em> republish the [=Recommendation=],
 	to make corrections that do not result
 	in any changes to the text of the specification.
+
+<h5 id="revised-rec-editorial">
+Revising a Recommendation: Editorial Changes</h5>
 
 	[=Editorial changes=] to a [=Recommendation=] require no technical review of the proposed changes.
 	A [=Working Group=],
@@ -3557,6 +3563,9 @@ Revising a Recommendation</h4>
 	or W3C <em class="rfc2119">may</em> publish a [=Recommendation=]
 	to make this class of change without passing through earlier maturity levels.
 	Such publications are called [=Edited Recommendations=].
+
+<h5 id="revised-rec-substantive">
+Revising a Recommendation: Substantive Changes</h5>
 
 	To make corrections to a Recommendation that produce [=substantive changes=]
 	but do not add new features,
@@ -3583,6 +3592,9 @@ Revising a Recommendation</h4>
 		<li>
 			<em class="rfc2119">should</em> address all recorded errata.
 	</ul>
+
+<h5 id="revised-rec-features">
+Revising a Recommendation: New Features</h5>
 
 	To make changes which introduce a new feature or features,
 	W3C <em class="rfc2119">must</em> follow the full process of <a href="#rec-advance">advancing a technical report to Recommendation</a>


### PR DESCRIPTION
This adds subsection headings to the section about REC revisions, without any other change to the text, to make future edits and reference to this part of the process easier.