### PR TITLE
description for "The Art of Consensus"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4997,7 +4997,7 @@ and the <a href="https://www.w3.org/2018/Process-20180201/">1 February 2018 Proc
 	},
 	"GUIDE": {
 		"href": "https://www.w3.org/Guide/",
-		"title": "The Art of Consensus",
+		"title": "The Art of Consensus", a guidebook for W3C Working Group Chairs and other collaborators
 		"publisher": "W3C"
 	},
 	"CEPC": {

--- a/index.bs
+++ b/index.bs
@@ -4997,7 +4997,7 @@ and the <a href="https://www.w3.org/2018/Process-20180201/">1 February 2018 Proc
 	},
 	"GUIDE": {
 		"href": "https://www.w3.org/Guide/",
-		"title": "The Art of Consensus", a guidebook for W3C Working Group Chairs and other collaborators
+		"title": "The Art of Consensus, a guidebook for W3C Working Group Chairs and other collaborators",
 		"publisher": "W3C"
 	},
 	"CEPC": {


### PR DESCRIPTION
This rewrite of the Process removed the description of what "The Art of Consensus" is. "Member Guide" I found to be misleading. If the description can be added to the "Informative References" section, that satisfies me.