### PR TITLE
Reduce redundant text about how to substantively revise a REC

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3511,15 +3511,9 @@ Revising a Recommendation: New Features</h5>
 	explicitly identified as [=allow new features|allowing new features=]
 	using [=candidate additions=].
 	A [=candidate addition=] can be made normative
-	and be folded into the main text of the [=Recommendation=],
-	once it has satisfied all the same criteria
-	as the rest of the [=Recommendation=],
-	including review by the community to ensure
-	the technical and editorial soundness of the [=candidate change=].
-	To validate this, the [=Working Group=] must request
-	a [=Last Call for Review of Proposed Changes=],
-	followed by an [=update request=].
-	See [[#change-review]].
+	and be folded into the main text of the [=Recommendation=]
+	using the same process as for [=candidate changes=],
+	as detailed in [[#revised-rec-substantive]].
 
 	Note: This prohibition against new features unless explicitly allowed
 	enables third parties to depend on Recommendations having a stable feature-set,


### PR DESCRIPTION
This attempts to address https://github.com/w3c/w3process/issues/358, by replacing redundant text with a reference to the part it duplicated.

An alternative (which I like less) can be seen at https://github.com/w3c/w3process/compare/main...frivoal:revising-rec-simplify-2

The merges the two sections sections instead of having one refer to the other. This doesn't significantly shorten the document (other than by removing one section title), and makes the new merged section longer (and IMO more confusing) as these two sections aren't redundant except for the part already addressed in the first proposal. The other ways by which they differ (to make class 3 changes, you may got back to CR, to make class 4, to FPWD) predate P2020, and used to be the only ways to make class 3 / 4 changes.

Both variants are equivalent from a normative standpoint. 
