### PR TITLE
Fix terminology mixup

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3568,7 +3568,7 @@ Incorporating Candidate Changes</h5>
 	with the [=proposed changes=] included in the [=Last Call for Review of Proposed Changes=]
 	is considered a [=Patent Review Draft=]
 	for the purposes of the Patent Policy [[PATENT-POLICY]].
-	Also, the review initiated by the [=Last Call for Review of Proposed Additions=]
+	Also, the review initiated by the [=Last Call for Review of Proposed Changes=]
 	is an [=Advisory Committee Review=].
 
 	Note: [=Last Call for Review of Proposed Additions=] and


### PR DESCRIPTION
Fixes a minor terminology mixup in https://w3c.github.io/w3process/#change-review

It's clear from context and other related parts what is meant here, but the correct word to use in that sentence is "Changes", not "Additions".

For instance, this bit of related text is written as if we got it right from the first place.

The section says:
> At the end of the Last Call for Review of Proposed Changes, the W3C
Decision may either be ...


and "W3C Decision" can only be done after AC Review:
> A W3C decision is one where the Director decides, after exercising the
role of assessing consensus of the W3C Community after an Advisory
Committee review.
