### PR TITLE
Define "CEO" and "Team Decision"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -526,10 +526,16 @@ The W3C Team</h3>
 	<dfn noexport lt="Team Decision | Team's Decision">Team Decisions</dfn> derive from the [=Director=] and [=CEO=]'s authority,
 	even when they are carried out by other members of the [=Team=].
 
+	<div class=issue>
+	It's bee suggested that the following note may be helpful,
+	but <a href="https://github.com/w3c/w3process/pull/438#issuecomment-693001060">this remains controversial</a>.
+	Should we include it?
+
 	Note: It is generally expected
 	that the CEO and Director will take the Team's input into consideration when making decisions,
 	and that they will delegate various responsibilities to individuals or groups within the Team.
 	Nevertheless, the CEO and Director have the ultimate authority within the Team.
+	</div>
 
 	The <dfn id="def-Director" export lt="Director|W3C Director">Director</dfn> is the lead technical architect at W3C,
 	whose responsibilities are identified throughout this document in relevant places.

--- a/index.bs
+++ b/index.bs
@@ -523,8 +523,7 @@ The W3C Team</h3>
 	(generally to other individuals in the Team)
 	for any of their roles described in this document,
 	except <a href="#tag-participation">participation in the TAG</a>.</p>
-	Decisions being described in this document
-	as being <dfn noexport lt="Team Decision | Team's Decision">Team Decisions</dfn> derive from the [=Director=] and [=CEO=]'s authority,
+	<dfn noexport lt="Team Decision | Team's Decision">Team Decisions</dfn> derive from the [=Director=] and [=CEO=]'s authority,
 	even when they are carried out by other members of the [=Team=].
 
 	Note: This does not imply that the CEO or Director are expected to make all decisions personally,

--- a/index.bs
+++ b/index.bs
@@ -507,7 +507,7 @@ The W3C Team</h3>
 
 	The <dfn export lt="Team | W3C Team">Team</dfn> consists of
 	the Director,
-	CEO,
+	<dfn>CEO</dfn>,
 	W3C paid staff,
 	unpaid interns,
 	and W3C Fellows.

--- a/index.bs
+++ b/index.bs
@@ -523,6 +523,9 @@ The W3C Team</h3>
 	(generally to other individuals in the Team)
 	for any of their roles described in this document,
 	except <a href="#tag-participation">participation in the TAG</a>.</p>
+	Decisions being described in this document
+	as being <dfn noexport lt="Team Decision | Team's Decision">Team Decisions</dfn> derive from the [=Director=] and [=CEO=]'s authority,
+	even when they are carried out by other members of the [=Team=].
 
 	The <dfn id="def-Director" export lt="Director|W3C Director">Director</dfn> is the lead technical architect at W3C,
 	whose responsibilities are identified throughout this document in relevant places.

--- a/index.bs
+++ b/index.bs
@@ -526,12 +526,9 @@ The W3C Team</h3>
 	<dfn noexport lt="Team Decision | Team's Decision">Team Decisions</dfn> derive from the [=Director=] and [=CEO=]'s authority,
 	even when they are carried out by other members of the [=Team=].
 
-	Note: This does not imply that the CEO or Director are expected to make all decisions personally,
-	and that the Team merely executes.
-	It is generally expected
-	that the CEO and Director will take the Team's input into consideration when making decisions personally,
-	and that they will delegate various responsibilities to individuals or groups within the Team,
-	as well as define the mechanisms by which this delegation is managed.
+	Note: It is generally expected
+	that the CEO and Director will take the Team's input into consideration when making decisions,
+	and that they will delegate various responsibilities to individuals or groups within the Team.
 	Nevertheless, the CEO and Director have the ultimate authority within the Team.
 
 	The <dfn id="def-Director" export lt="Director|W3C Director">Director</dfn> is the lead technical architect at W3C,

--- a/index.bs
+++ b/index.bs
@@ -527,6 +527,14 @@ The W3C Team</h3>
 	as being <dfn noexport lt="Team Decision | Team's Decision">Team Decisions</dfn> derive from the [=Director=] and [=CEO=]'s authority,
 	even when they are carried out by other members of the [=Team=].
 
+	Note: This does not imply that the CEO or Director are expected to make all decisions personally,
+	and that the Team merely executes.
+	It is generally expected
+	that the CEO and Director will take the Team's input into consideration when making decisions personally,
+	and that they will delegate various responsibilities to individuals or groups within the Team,
+	as well as define the mechanisms by which this delegation is managed.
+	Nevertheless, the CEO and Director have the ultimate authority within the Team.
+
 	The <dfn id="def-Director" export lt="Director|W3C Director">Director</dfn> is the lead technical architect at W3C,
 	whose responsibilities are identified throughout this document in relevant places.
 	Some key ones include:


### PR DESCRIPTION
One thing that is annoying from an editorial standpoint when working on director-free related issues and pull requests is that even though we may want to reassign some decisions/responsibilities/actions to the CEO and some to the Team, "CEO" and "Team decision" aren't currently defined terms on the main branch, so I can't use them with a bikeshed cross-link in any pull request based on the main branch.

This pull request formally defines these terms, so that they can be used as a basis for further work. It does not by itself make any change to who decides what. Based on discussions held in the AB, including at the Quebec F2F, this also includes a Note that clarifies the relationship between the Team and the CEO/Director.

I've had this written up for a while on a separate branch (and it's been part of the [director-free consolidated branch](https://github.com/w3c/w3process/tree/director-free)), with all my other director-free topic branches being based off that, but branches on top of branches is annoying to maintain.

Since this is only defining terms and adding a note that should already be true today, this is editorial, and I would appreciate if we could merge this (or something similar) now, so that I can spend more of my "director free" time on the actual issues and less on rebasing branches.