### PR TITLE
Note track

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2819,6 +2819,13 @@ Maturity Levels on the Recommendation Track</h4>
 					See also “W3C Royalty-Free (RF) Licensing Requirements”
 					in the W3C Patent Policy [[!PATENT-POLICY]].
 			</dl>
+		<dt>
+			<dfn id="discontinuedREC" export >Discontinued Draft</dfn>
+		<dd>
+			A [=technical report=] representing the state of a Recommendation-track document
+			at the point at which work on it was discontinued.
+			See [[#abandon-draft]].
+
 	</dl>
 
 	Only sufficiently technically mature work should be advanced.
@@ -3144,6 +3151,7 @@ Revising a Working Draft</h4>
 		<li>Revised <a href="#revising-wd">Working Draft</a>
 		<li><a href="#transition-cr">Candidate Recommendation</a>
 		<li><a href="#Note">Working Group Note</a>
+		<li><a href="#abandon-draft">Discontinued Draft</a></li>
 	</ul>
 
 <h4 id="transition-cr" oldids="candidate-rec, last-call">
@@ -3196,7 +3204,7 @@ Transitioning to Candidate Recommendation</h4>
 		<li>A revised <a href="#publishing-crrs">Candidate Recommendation Snapshot</a></li>
 		<li>A revised <a href="#publishing-crud">Candidate Recommendation Draft</a></li>
 		<li><a href="#transition-pr">Proposed Recommendation</a></li>
-		<li><a href="#Note">Working Group Note</a></li>
+		<li><a href="#abandon-draft">Discontinued Draft</a></li>
 	</ul>
 
 	[=Advisory Committee=] representatives <em class="rfc2119">may</em> initiate an
@@ -3302,7 +3310,7 @@ Publishing a [=Candidate Recommendation Draft=]</h5>
 		<li>A revised <a href="#publishing-crud">Candidate Recommendation Draft</a></li>
 		<li><a href="#transition-pr">Proposed Recommendation</a>,
 		if there are no [=substantive change=] other than dropping [=at risk=] features</li>
-		<li><a href="#Note">Working Group Note</a></li>
+		<li><a href="#abandon-draft">Discontinued Draft</a></li>
 	</ul>
 
 
@@ -3399,7 +3407,7 @@ Transitioning to Proposed Recommendation</h4>
 			(the expected next step).
 
 		<li>
-			<a href="#Note">Working Group Note</a>
+			<a href="#abandon-draft">Discontinued Draft</a></li>
 	</ul>
 
 	[=Advisory Committee representatives=] <em class="rfc2119">may</em> initiate an [=Advisory Committee Appeal=]
@@ -3627,19 +3635,26 @@ Abandoning an Unfinished Technical Report</h5>
 	Any [=technical report=] no longer intended
 	to advance or to be maintained,
 	and that is not being rescinded,
-	<em class="rfc2119">should</em> be [=published=] as a [=Working Group Note=].
+	<em class="rfc2119">should</em> be [=published=]
+	as a [=Discontinued Draft=],
+	with no [=substantive change=] compared to the previous publication.
 	This can happen if
 	the [=Working Group=] decided
 	to abandon work on the report,
 	or the [=Director=] required the [=Working Group=]
 	to discontinue work on the technical report before completion.
 	If a [=Working Group=] is made to <a href="#GeneralTermination">close</a>,
-	W3C <em class="rfc2119">must</em> [=publish=] any unfinished [=technical report=]
-	on the Recommendation track as [=Working Group Notes=].
+	W3C <em class="rfc2119">must</em> re-[=publish=] any unfinished [=technical report=]
+	on the Recommendation track as [=Discontinued Draft=].
 
-	Such a document should be documented as discontinued in its status section,
-	with a <a href="#abandon-draft">link to this section of this document</a>,
-	and accompanied by an explanation of why it was discontinued.
+	Such a document should include in its status section
+	an explanation of why it was discontinued.
+
+	A [=Working Group=] <em class="rfc2119">may</em> resume work
+	on a [=technical report=]
+	within the scope of its charter
+	at any time,
+	by re-[=publishing=] it as a [=Working Draft=].
 
 <h5 id=rescind-cr>
 Rescinding a Candidate Recommendation</h5>
@@ -3801,8 +3816,7 @@ Working Group and Interest Group Notes</h3>
 	is published
 	by a chartered [=Working Group=] or [=Interest Group=]
 	to provide a stable reference for a useful document
-	that is not intended to be a formal standard,
-	or to document work that was abandoned without producing a [=Recommendation=].
+	that is not intended to be a formal standard.
 
 	[=Working Groups=] and [=Interest Groups=] <em class="rfc2119">may</em> publish work as [=W3C Notes=].
 	Examples include:
@@ -3815,10 +3829,6 @@ Working Group and Interest Group Notes</h3>
 
 		<li>
 			non-normative guides to good practices,
-
-		<li>
-			specifications where work has been stopped
-			and there is no longer consensus for making them a new standard.
 	</ul>
 
 	Some [=W3C Notes=] are developed through successive [=Working Drafts=],
@@ -3853,13 +3863,6 @@ Working Group and Interest Group Notes</h3>
 			End state:
 			A technical report <em class="rfc2119">may</em> remain
 			a Working or Interest Group [=Note=] indefinitely
-
-		<li>
-			A [=Working Group=] <em class="rfc2119">may</em> resume work
-			on a technical report
-			within the scope of its charter
-			at any time,
-			at the maturity level the specification had before publication as a [=Note=]
 	</ul>
 
 	Note: The W3C Patent Policy [[PATENT-POLICY]]

--- a/index.bs
+++ b/index.bs
@@ -2893,7 +2893,7 @@ Implementation Experience</h4>
 Advancement on the Recommendation Track</h4>
 
 	For <em>all</em> requests to advance a specification
-	to a new maturity level other than [=Note=]
+	to a new maturity level
 	(called <dfn id=trans-req export>Transition Requests</dfn>),
 	the Working Group:
 
@@ -3150,7 +3150,6 @@ Revising a Working Draft</h4>
 	<ul>
 		<li>Revised <a href="#revising-wd">Working Draft</a>
 		<li><a href="#transition-cr">Candidate Recommendation</a>
-		<li><a href="#Note">Working Group Note</a>
 		<li><a href="#abandon-draft">Discontinued Draft</a></li>
 	</ul>
 
@@ -3831,24 +3830,20 @@ Working Group and Interest Group Notes</h3>
 			non-normative guides to good practices,
 	</ul>
 
-	Some [=W3C Notes=] are developed through successive [=Working Drafts=],
-	with an expectation that they will become [=Notes=],
-	while others are simply [=published=].
-	There are few formal requirements to [=publish=] a document as a [=W3C Note=],
+	Some [=W3C Notes=] are developed through successive <dfn lt="Draft Note">Draft Notes</dfn>
+	before publication as a full [=Notes=],
+	while others are [=published=] directly as a [=Note=].
+	There are few formal requirements to [=publish=] a document as a [=W3C Note=] or [=Draft Note=],
 	and they have no standing as a recommendation of W3C
 	but are simply documents preserved for historical reference.
 
-	In order to publish a [=Note=],
+	In order to publish a [=Note=] or [=Draft Note=],
 	a [=Working Group=] or [=Interest Group=]:
 
 	<ul>
 		<li>
-			<em class="rfc2119">may</em> [=publish=] a [=Note=]
-			with or without its prior publication as a [=Working Draft=].
-
-		<li>
 			<em class="rfc2119">must</em> record the group's decision
-			to request publication as a [=Note=], and
+			to request publication as a [=Note=] or [=Draft Note=], and
 
 		<li>
 			<em class="rfc2119">should</em> publish documentation
@@ -3856,17 +3851,13 @@ Working Group and Interest Group Notes</h3>
 			since any previous publication.
 	</ul>
 
-	Possible next steps:
-
-	<ul>
-		<li>
-			End state:
-			A technical report <em class="rfc2119">may</em> remain
-			a Working or Interest Group [=Note=] indefinitely
-	</ul>
+	Both [=Notes=] and [=Draft Notes=] can be updated by republishing
+	as a [=Note=] or [=Draft Note=].
+	A [=technical report=] <em class="rfc2119">may</em> remain
+	a Working or Interest Group [=Note=] indefinitely.
 
 	Note: The W3C Patent Policy [[PATENT-POLICY]]
-	does not specify any licensing requirements or commitments for Working Group Notes.
+	does not specify any licensing requirements or commitments for Working Group Notes or Draft Notes.
 
 <h3 id="further-reading">
 Further reading</h3>


### PR DESCRIPTION
Separates the Note Track from the REC Track. The REC track is under the patent policy, while the Note Track isn't. The fact that they shared some stages has been messy. There were previously two connections: FPWD (and other WD) could be used as a first stage for Notes, and Notes were a way to discontinue REC track documents. This pull request separates them by introducing "Draft Note" to replace working drafts of notes and "Discontinued Draft Recommendation" to replace notes of abandoned REC-track work.

If accepted, this would close #342


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/488.html" title="Last updated on Feb 24, 2021, 4:32 PM UTC (3105678)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/488/7bdea3e...frivoal:3105678.html" title="Last updated on Feb 24, 2021, 4:32 PM UTC (3105678)">Diff</a>