### PR TITLE
W3C Statements (formerly Memoranda)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3812,15 +3812,18 @@ Process for Rescinding, Obsoleting, Superseding, Restoring a Recommendation</h5>
 
 
 <h3 id="Note">
-Working Group and Interest Group Notes</h3>
+Group Notes</h3>
 
-	A <dfn export id="WGNote" lt="W3C Note | WG Note | Working Group Note | IG Note | Interest Group Note | Note">Working Group Note or Interest Group Note</dfn> (<abbr>NOTE</abbr>)
+	A <dfn export id="WGNote" lt="Group Note | Note | W3C Note | Working Group Note | Interest Group Note | AB Note | TAG Note">Group Note</dfn> (<abbr>NOTE</abbr>)
 	is published
-	by a chartered [=Working Group=] or [=Interest Group=]
 	to provide a stable reference for a useful document
 	that is not intended to be a formal standard.
 
-	[=Working Groups=] and [=Interest Groups=] <em class="rfc2119">may</em> publish work as [=W3C Notes=].
+	[=Working Groups=],
+	[=Interest Groups=],
+	the [=TAG=]
+	and the [=AB=]
+	<em class="rfc2119">may</em> publish work as [=Notes=].
 	Examples include:
 
 	<ul>
@@ -3833,19 +3836,19 @@ Working Group and Interest Group Notes</h3>
 			non-normative guides to good practices,
 	</ul>
 
-	Some [=W3C Notes=] are developed through successive <dfn lt="Draft Note">Draft Notes</dfn>
+	Some [=Notes=] are developed through successive <dfn lt="Draft Note">Draft Notes</dfn>
 	before publication as a full [=Notes=],
 	while others are [=published=] directly as a [=Note=].
-	There are few formal requirements to [=publish=] a document as a [=W3C Note=] or [=Draft Note=],
+	There are few formal requirements to [=publish=] a document as a [=Note=] or [=Draft Note=],
 	and they have no standing as a recommendation of W3C
 	but are simply documents preserved for historical reference.
 
 	In order to publish a [=Note=] or [=Draft Note=],
-	a [=Working Group=] or [=Interest Group=]:
+	the group:
 
 	<ul>
 		<li>
-			<em class="rfc2119">must</em> record the group's decision
+			<em class="rfc2119">must</em> record their decision
 			to request publication as a [=Note=] or [=Draft Note=], and
 
 		<li>
@@ -3857,10 +3860,10 @@ Working Group and Interest Group Notes</h3>
 	Both [=Notes=] and [=Draft Notes=] can be updated by republishing
 	as a [=Note=] or [=Draft Note=].
 	A [=technical report=] <em class="rfc2119">may</em> remain
-	a Working or Interest Group [=Note=] indefinitely.
+	a [=Note=] indefinitely.
 
 	Note: The W3C Patent Policy [[PATENT-POLICY]]
-	does not specify any licensing requirements or commitments for Working Group Notes or Draft Notes.
+	does not apply any licensing requirements or commitments for [=Notes=] or [=Draft Notes=].
 
 <h3 id="further-reading">
 Further reading</h3>

--- a/index.bs
+++ b/index.bs
@@ -3905,6 +3905,28 @@ Elevating Group Notes to W3C Statement status</h4>
 	The [=Team=] must announce the publication of a [=W3C Statement=]
 	to the [=Advisory Committee=], other W3C groups, and the public.
 
+<h4 id=revising-memo>
+Revising W3C Statements</h4>
+
+	Given a recorded [=Group Decision=] to do so,
+	groups can request publication of a [=W3C Statement=] with [=editorial changes=]--
+	including [=candidate amendment=]--
+	without any additional process.
+
+	A [=candidate amendment=] can be folded into the main text of the [=W3C Statement=],
+	once it has satisfied all the same criteria
+	as the rest of the [=Statement=],
+	including review by the community to ensure
+	the substantive and editorial soundness of the [=candidate amendments=].
+	To validate this, the group must request
+	an [=Advisory Committee review=] of the changes it wishes to incorporate.
+	The specific [=candidate amendments=] under review
+	<em class=rfc2119>must</em> be identified as [=proposed amendments=]
+	just as in a [=Last Call for Review of Proposed Corrections=].
+
+	The decision to incorporate [=proposed amendments=] into [=W3C Statement=] is a [=W3C Decision=].
+	[=Advisory Committee representatives=] may initiate an [=Advisory Committee Appeal=] of the decision.
+
 <h3 id="further-reading">
 Further reading</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -3892,6 +3892,12 @@ Elevating Group Notes to W3C Statement status</h4>
 			provide public documentation of any [=Formal Objections=].
 	</ul>
 
+	A [=Note=] specifying implementable technology <em rfc=2119>should not</em> be elevated to [=W3C Statement=] status;
+	if it does,
+	the request to publish as a [=Statement=] <em class=rfc2119>must</em> include rationale
+	for why it should be elevated,
+	and why it is not on the [=Recommendation track=].
+
 	Once these conditions are fulfilled,
 	the [=Team=] <em class=rfc2119>must</em> then
 	begin an Advisory Committee Review on the question of

--- a/index.bs
+++ b/index.bs
@@ -3811,8 +3811,11 @@ Process for Rescinding, Obsoleting, Superseding, Restoring a Recommendation</h5>
 	will continue to be available at their version-specific URL.
 
 
-<h3 id="Note">
-Group Notes</h3>
+<h3 id=note-track>
+Note Track: Notes and Statements</h3>
+
+<h4 id="Note">
+Group Notes</h4>
 
 	A <dfn export id="WGNote" lt="Group Note | Note | W3C Note | Working Group Note | Interest Group Note | AB Note | TAG Note">Group Note</dfn> (<abbr>NOTE</abbr>)
 	is published
@@ -3864,6 +3867,43 @@ Group Notes</h3>
 
 	Note: The W3C Patent Policy [[PATENT-POLICY]]
 	does not apply any licensing requirements or commitments for [=Notes=] or [=Draft Notes=].
+
+<h4 id=memo>
+Elevating Group Notes to W3C Statement status</h4>
+
+	A <dfn lt="Statement | W3C Statement">W3C Statement</dfn> is a [=Note=]
+	that has been endorsed by W3C as a whole.
+	In order to elevate a [=Note=] to [=W3C Statement=] status,
+	A group <em class=rfc2119>must</em>:
+
+	<ul>
+		<li>
+			show that the document has received [=wide review=].
+
+		<li>
+			record the group’s decision to request publication as a [=W3C Statement=].
+
+		<li>
+			show that all issues raised against the document
+			since its first publication as a [=Note=]
+			have been [=formally addressed=].
+
+		<li>
+			provide public documentation of any [=Formal Objections=].
+	</ul>
+
+	Once these conditions are fulfilled,
+	the [=Team=] <em class=rfc2119>must</em> then
+	begin an Advisory Committee Review on the question of
+	whether the document is appropriate to publish as a [=W3C Statement=].
+	During this review period,
+	the [=Note=] <em class=rfc2119>must not</em> be updated.
+
+	The decision to advance a document to [=W3C Statement=] is a [=W3C Decision=].
+	[=Advisory Committee representatives=] may initiate an [=Advisory Committee Appeal=] of the decision.
+
+	The [=Team=] must announce the publication of a [=W3C Statement=]
+	to the [=Advisory Committee=], other W3C groups, and the public.
 
 <h3 id="further-reading">
 Further reading</h3>


### PR DESCRIPTION
This pull request builds upon #488, and the first 2 commits belong to that, rather than this pull request specifically. To avoid confusion, please review the last 4 commits  (8d37bfa 168d7ef dae9fdb 98194d3) individually, rather than the pull request as a whole!!!!!

Note: If you complain that the whole thing is too long, I'll know you ignored the above info :-)

This Pull Request:
    * Enables the AB and TAG to publish Notes
    * Enables Notes to be endorsed by the whole W3C through AC review and thereby become W3C Memoranda
    * Define how to revise W3C Memoranda once issued

See #461


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/489.html" title="Last updated on Feb 24, 2021, 4:45 PM UTC (43a01da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/489/4dbbe24...frivoal:43a01da.html" title="Last updated on Feb 24, 2021, 4:45 PM UTC (43a01da)">Diff</a>