### PR TITLE
Distinguish Team corrections from other candidate corrections

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2547,11 +2547,13 @@ Candidate Amendments</h4>
 	If there is no group chartered to maintain a [=technical report=],
 	the [=Team=] <em class="rfc2119">may</em> maintain its [=errata=]
 	and associated [=candidate corrections=].
-	When doing so,
-	it <em class=rfc2119>must</em> be explicit that those [=errata=] and [=candidate corrections=]
-	were written by the [=Team=].
+	Such corrections <em class=rfc2119>must</em> be marked
+	as <dfn>Team correction</dfn>,
+	and are considered non-normative
+	(i.e. not covered)
+	for the purposes of the Patent Policy.
 	The [=Team=] <em class=rfc2119>must</em> solicit [=wide review=]
-	on [=candidate corrections=] that it produces.
+	on [=Team corrections=] that it produces.
 
 	[=Candidate corrections=] and [=candidate additions=] are collectively known as
 	<dfn lt="candidate amendment">candidate amendments</dfn>.
@@ -3490,7 +3492,7 @@ Revising a Recommendation: Editorial Changes</h5>
 	If there is no [=Working Group=] chartered to maintain a [=Recommendation=],
 	the [=Team=] <em class="rfc2119">may</em> republish the [=Recommendation=]
 	with such changes incorporated,
-	including [=errata=] and [=candidate corrections=].
+	including [=errata=] and [=Team corrections=].
 
 <h5 id="revised-rec-substantive">
 Revising a Recommendation: Substantive Changes</h5>

--- a/index.bs
+++ b/index.bs
@@ -2549,9 +2549,10 @@ Candidate Amendments</h4>
 	and associated [=candidate corrections=].
 	Such corrections <em class=rfc2119>must</em> be marked
 	as <dfn>Team correction</dfn>,
-	and are considered non-normative
-	(i.e. not covered)
-	for the purposes of the Patent Policy.
+	and do not constitute
+	a normative portion of the Recommendation,
+	as defined in the Patent Policy [[PATENT-POLICY]]
+	(i.e. they are not covered by the Patent Policy).
 	The [=Team=] <em class=rfc2119>must</em> solicit [=wide review=]
 	on [=Team corrections=] that it produces.
 


### PR DESCRIPTION
This helps reminding people that they're not covered by the Patent Policy.

See #493


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/494.html" title="Last updated on Feb 10, 2021, 2:09 PM UTC (ed325b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/494/7bdea3e...frivoal:ed325b2.html" title="Last updated on Feb 10, 2021, 2:09 PM UTC (ed325b2)">Diff</a>