### PR TITLE
Use the username 'w3cbot' to interact with GitHub

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -21,14 +21,14 @@ jobs:
       - name: Setup python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
           architecture: x64
       - name: Install bikeshed
         run: |
           pip install bikeshed
           bikeshed update
           echo Bikeshed is ready
-      - name: Run the script that invokes python
+      - name: Run deploy.sh
       # don't forget: git update-index --chmod +x ./deploy.sh
         run: ./deploy.sh
         shell: bash

--- a/deploy.sh
+++ b/deploy.sh
@@ -34,12 +34,8 @@ set -x
 
 # set up the github credentials
 
-# GITHUB_EVENT_PATH is a JSON file so ...this is a bit of a hack...
-PULL_AUTHOR_EMAIL=`cat $GITHUB_EVENT_PATH | grep email | head -n 1 | cut -d ":" -f2 | cut -d '"' -f2`
-COMMIT_AUTHOR_EMAIL=${PULL_AUTHOR_EMAIL:-"github-action@users.noreply.github.com"}
-
-git config --global user.email $COMMIT_AUTHOR_EMAIL
-git config --global user.name $GITHUB_ACTOR
+git config --global user.email noreply@unknown.w3.org
+git config --global user.name w3cbot
 git config --global user.password $GITHUB_TOKEN
 
 REPO_URL="https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"


### PR DESCRIPTION
The [GITHUB_TOKEN](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret) needs a valid username but it seems it could be any user, not just [GITHUB_ACTOR](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context).
Email address can be anything.
