### PR TITLE
Make it possible to transition from REC to WD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3689,7 +3689,9 @@ Revising a Recommendation: Substantive Changes</h5>
 
 	Alternatively,
 	a [=Working Group=] <em class="rfc2119">may</em> incorporate the changes
-	and <a href="#transition-cr">publish as a Candidate Recommendation</a>,
+	and <a href="#revising-wd">publish as a Working Draft</a>--
+	or, if the relevant criteria are fulfilled,
+	<a href="#transition-cr">publish as a Candidate Recommendation</a>--
 	and advance the specification from that state.
 	(See <a href="#correction-classes">class 3 changes</a>.)
 


### PR DESCRIPTION
It was already possible to go from REC to CR, and from CR to WD, but
a strict reading made it look like going from REC to WD was not
possible, which would be odd.

See #103


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/562.html" title="Last updated on Aug 12, 2021, 3:35 PM UTC (ef772e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/562/ae375e2...frivoal:ef772e2.html" title="Last updated on Aug 12, 2021, 3:35 PM UTC (ef772e2)">Diff</a>