### PR TITLE
Stop excluding AC rep comments from those that have to be addressed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3515,8 +3515,6 @@ Transitioning to Proposed Recommendation</h4>
 		<li>
 			<em class="rfc2119">must</em> show that all issues
 			raised during the [=Candidate Recommendation=] review period
-			other than by [=Advisory Committee representatives=]
-			acting in their formal [=AC representative=] role
 			have been [=formally addressed=],
 
 		<li>


### PR DESCRIPTION
Comments made during the CR phase, by AC reps acting in their formal capacity, could until now be ignored by the WG, since they could be caught by the Director at a later stage during the transition request.

Assuming either an exhaustive disposition of comments, or that the AC Rep remembers to file a Formal Objection, such comments would indeed not be lost.

However, it is generally preferable to deal with issues early rather than late. This commit makes it so that AC Rep comments deserve a WG response as much as anyone else's.

See #339


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/563.html" title="Last updated on Aug 12, 2021, 3:46 PM UTC (eb7d9ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/563/ae375e2...frivoal:eb7d9ac.html" title="Last updated on Aug 12, 2021, 3:46 PM UTC (eb7d9ac)">Diff</a>