### PR TITLE
Use "allow new features" terminology consistently

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3716,8 +3716,7 @@ Revising a Recommendation: New Features</h5>
 	as they have prior to the 2020 revision of this Process.
 
 	To make changes which introduce a new feature
-	to a [=Recommendation=]
-	that was not approved for accepting new features,
+	to a [=Recommendation=] that does not [=allow new features=],
 	W3C <em class="rfc2119">must</em> create a new [=technical report=],
 	following the full process of <a href="#rec-advance">advancing a technical report to Recommendation</a>
 	beginning with a new [=First Public Working Draft=].


### PR DESCRIPTION
Final paragraph in [section 6.2.11.4 Revising a Recommendation: New Features](https://www.w3.org/2020/Process-20200915/#revised-rec-features) used the undefined expression "approved for accepting new features", making it unclear when and where that "approval" was granted (In the process? In the Working Group charter? In the spec itself?)

This update removes the ambiguity by replacing the expression with a link to the "allow new features" concept, which explains the mechanism.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/w3process/pull/567.html" title="Last updated on Aug 18, 2021, 9:16 PM UTC (3fa6ee4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/567/59d8f7c...tidoust:3fa6ee4.html" title="Last updated on Aug 18, 2021, 9:16 PM UTC (3fa6ee4)">Diff</a>