### PR TITLE
Require document license to go through formal approval for updates

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -66,7 +66,7 @@ Boilerplate: repository-issue-tracking off
 </pre>
 <pre class=biblio>
 {
-	"PATENT-POLICY": {
+	"PATENT-POLICY-2020": {
 		"href": " https://www.w3.org/Consortium/Patent-Policy-20200915/",
 		"title": "The W3C 2020 Patent Policy"
 	}
@@ -2790,9 +2790,9 @@ The W3C Recommendation Track</h3>
 
 	This Process defines certain [=Recommendation Track=] publications as <dfn>Patent Review Drafts</dfn>.
 	Under the 2004 (updated in 2017) Patent Policy,
-	these correspond to “Last Call Working Draft” in the Patent Policy [[!PATENT-POLICY-2017]];
+	these correspond to “Last Call Working Draft” in the Patent Policy [[!PATENT-POLICY-2004]];
 	Under the 2020 Patent Policy,
-	these correspond to “Patent Review Draft” in the Patent Policy [[!PATENT-POLICY]].
+	these correspond to “Patent Review Draft” in the Patent Policy [[!PATENT-POLICY-2020]].
 
 	W3C <em class="rfc2119">may</em> <a href="#tr-end">end work on a technical report</a> at any time.
 
@@ -5474,7 +5474,7 @@ Changes since earlier versions</h3>
 		"title": "The W3C Patent Policy",
 		"publisher": "W3C"
 	},
-	"PATENT-POLICY-2017": {
+	"PATENT-POLICY-2004": {
 		"href": "https://www.w3.org/Consortium/Patent-Policy-20170801/",
 		"title": "The W3C 2004 Patent Policy, Updated 2017",
 		"publisher": "W3C"

--- a/index.bs
+++ b/index.bs
@@ -2789,10 +2789,10 @@ The W3C Recommendation Track</h3>
 	</div>
 
 	This Process defines certain [=Recommendation Track=] publications as <dfn>Patent Review Drafts</dfn>.
-	Under the 2004 (updated in 2017) Patent Policy,
-	these correspond to “Last Call Working Draft” in the Patent Policy [[!PATENT-POLICY-2004]];
-	Under the 2020 Patent Policy,
-	these correspond to “Patent Review Draft” in the Patent Policy [[!PATENT-POLICY-2020]].
+	Under the 2004 Patent Policy (and its 2017 update) [[!PATENT-POLICY-2004]],
+	these correspond to “Last Call Working Draft” in the Patent Policy;
+	Starting from the 2020 Patent Policy [[!PATENT-POLICY-2020]],
+	these correspond to “Patent Review Draft” in the Patent Policy [[!PATENT-POLICY]].
 
 	W3C <em class="rfc2119">may</em> <a href="#tr-end">end work on a technical report</a> at any time.
 

--- a/index.bs
+++ b/index.bs
@@ -5013,6 +5013,7 @@ Process Evolution</h2>
 	* the W3C Process (this document)
 	* the W3C Patent Policy [[!PATENT-POLICY]]
 	* the W3C Code of Ethics and Professional Conduct [[!CEPC]]
+	* The W3C Document License [[!DOC-LICENSE]]
 
 	The [=Advisory Board=] initiates review as follows:
 


### PR DESCRIPTION
Ensures all policies binding on members either are dated or go through AC approval.

This addresses the part of @jwrosewell's formal objection on normative dependencies. With this in place, the normative references are as follows:

Covered by section 11 formal approval:
* [CEPC]
* [DOC-LICENSE] (just added)
* [PATENT-POLICY]

Not binding on Members via Member agreement:
* [COLLABORATORS-AGREEMENT] (applies to signers only)
* [CONFLICT-POLICY] (applies to Team only, not a concern for members)
* [PUBRULES] (applies to documents, not people; merely documents what is formally defined by the Process as being the Team's judgement call on publishability)

No need to be dated, because RFCs [cannot change after publication](https://www.rfc-editor.org/faq/#errata):
* [RFC2119]
* [RFC3797]


@jwrosewell, can you review and let us know whether this change addresses your comment? (See https://github.com/w3c/w3process/pull/572 for the issue about precedence.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/571.html" title="Last updated on Aug 31, 2021, 5:59 AM UTC (bd4ebc7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/571/b9d22e7...frivoal:bd4ebc7.html" title="Last updated on Aug 31, 2021, 5:59 AM UTC (bd4ebc7)">Diff</a>