### PR TITLE
Let the Team rather than the Director handle progression on TR

### DIFF
--- a/basic-rec-track.svg
+++ b/basic-rec-track.svg
@@ -11,7 +11,7 @@
 						<text font-size="8">
 							<tspan aria-hidden="true" y="132" x="0">First Public WD</tspan>
 							<tspan x="0" y="152">WG decision</tspan>
-							<tspan x="0" y="162">Director's approval</tspan>
+							<tspan x="0" y="162">Team's approval</tspan>
 						</text>
 						<path d="M0,140h53" fill="none" stroke="#000"></path>
 						<polygon points="47,136 57,140 47,144"></polygon>
@@ -46,7 +46,7 @@
 								<g role="img">
 									<title>Advance to Candidate Recommendation</title>
 								</g>
-								<text x="138" y="134" font-size="8">Director's approval</text>
+								<text x="138" y="134" font-size="8">Team's approval</text>
 								<path stroke="#060" d="M135,140h81"></path>
 								<polygon points="211,136 221,140 211,144"></polygon>
 							</a>
@@ -102,7 +102,7 @@
 								</g>
 								<text font-size="8">
 									<tspan x="288" y="104">WG Decision +</tspan>
-									<tspan x="288" y="112">Director’s approval</tspan>
+									<tspan x="288" y="112">Team’s approval</tspan>
 								</text>
 								<path stroke="#000" d="M286,127v-34"></path>
 								<polygon points="286,128 282,118 290,118"></polygon>
@@ -116,7 +116,7 @@
 								</g>
 								<text font-size="8">
 									<tspan x="182" y="112">WG Decision</tspan>
-									<tspan x="288" y="112">Director’s approval</tspan>
+									<tspan x="288" y="112">Team’s approval</tspan>
 								</text>
 								<path stroke="#000" d="M242,124C238,114 244,104 260,104 271,104 277,108 279,114" stroke-dasharray="5 11" fill="none"></path>
 								<path stroke="#060" d="M242,124C238,114 244,104 260,104 271,104 277,108 279,114" stroke-dasharray="5 11" stroke-dashoffset="8" fill="none"></path>
@@ -129,7 +129,7 @@
 							<g role="img">
 							<title>Advance to Proposed Recommendation</title>
 							</g>
-							<text x="300" y="134" font-size="8">Director's approval</text>
+							<text x="300" y="134" font-size="8">Team's approval</text>
 							<path d="M298,140h77" stroke="#060"></path>
 							<polygon points="374,136 384,140 374,144"></polygon>
 						</a>
@@ -141,7 +141,7 @@
 								<title>Return to Working Draft</title>
 								</g>
 								<text font-size="8">
-									<tspan x="142" y="160">WG or Director decision</tspan>
+									<tspan x="142" y="160">WG or Team decision</tspan>
 									<tspan x="144" y="170">e.g. for further review</tspan>
 								</text>
 								<path d="M140,147h84" stroke-dasharray="4 4" stroke="#600"></path>
@@ -167,7 +167,7 @@
 								</g>
 								<text x="300" y="138" font-size="8">
 									<tspan x="445" y="124">Advisory Committee Review</tspan>
-									<tspan x="445" y="134">Director's Decision</tspan>
+									<tspan x="445" y="134">Team's Decision</tspan>
 								</text>
 								<path d="M441,140h100" stroke="#060"></path>
 								<polygon points="534,136 544,140 534,144"></polygon>
@@ -181,7 +181,7 @@
 								</g>
 								<text font-size="8">
 									<tspan x="306" y="160">AC Review, </tspan>
-									<tspan x="302" y="170">Director Decision</tspan>
+									<tspan x="302" y="170">Team Decision</tspan>
 									<tspan x="304" y="180">e.g. for editorial changes</tspan>
 								</text>
 								<path d="M301,147h88" stroke-dasharray="3 5" stroke="#600"></path>
@@ -195,7 +195,7 @@
 									<title>Return to Working Draft</title>
 								</g>
 								<text font-size="9">
-									<tspan x="90" y="202">Advisory Committee review and Director's Decision, e.g. for further work and review</tspan>
+									<tspan x="90" y="202">Advisory Committee review and Team's Decision, e.g. for further work and review</tspan>
 								</text>
 								<path d="M413,158v32h-316v-26" stroke-dasharray="2 2" stroke="#c00" fill="none"></path>
 								<polygon points="95,164 97,159 99,164"></polygon>

--- a/index.bs
+++ b/index.bs
@@ -2547,7 +2547,7 @@ Wide Review</h5>
 	early enough that comments and suggested changes
 	can still be reasonably incorporated in response to the review.
 	Before approving transitions,
-	the [=Director=] will consider who has been explicitly offered
+	the [=Team=] will consider who has been explicitly offered
 	a reasonable opportunity to review the document,
 	who has provided comments,
 	the record of requests to and responses from reviewers,
@@ -2788,7 +2788,8 @@ The W3C Recommendation Track</h3>
 
 	W3C <em class="rfc2119">may</em> <a href="#tr-end">end work on a technical report</a> at any time.
 
-	The Director <em class="rfc2119">may</em> decline a request to advance in maturity level,
+	The [=Team=] <em class="rfc2119">may</em> [=Team Decision|decide=]
+	to decline a request to advance in maturity level,
 	requiring a [=Working Group=] to conduct further work,
 	and <em class="rfc2119">may</em> require
 	the specification to return to a lower <a href="#maturity-levels">maturity level</a>.
@@ -3023,7 +3024,7 @@ Implementation Experience</h4>
 	of each feature of the specification will be realized.
 	While no exhaustive list of requirements is provided here,
 	when assessing that there is <dfn id="adequate-implementation">adequate implementation experience</dfn>
-	the [=Director=] will consider (though not be limited to):
+	the [=Team=] will consider (though not be limited to):
 
 	<ul>
 		<li>
@@ -3068,7 +3069,7 @@ Advancement on the Recommendation Track</h4>
 			<em class="rfc2119">must</em> record the group's decision to request advancement.
 
 		<li>
-			<em class="rfc2119">must </em> obtain [=Director=] approval.
+			<em class="rfc2119">must </em> obtain [=Team=] approval.
 
 		<li>
 			<em class="rfc2119 ">must</em> publicly document all new features
@@ -3121,7 +3122,7 @@ Updating Mature Publications on the Recommendation Track</h4>
 	Certain requests to re-publish a specification
 	within its current maturity level
 	(called <dfn export>Update Requests</dfn>)
-	require [=Director=] approval.
+	require [=Team=] approval.
 	For such [=update requests=], the Working Group:
 
 	<ul>
@@ -3132,7 +3133,7 @@ Updating Mature Publications on the Recommendation Track</h4>
 			<em class="rfc2119">must</em> show that the changes have received [=wide review=].
 
 		<li>
-			<em class="rfc2119">must </em> obtain [=Director=] approval,
+			<em class="rfc2119">must </em> obtain [=Team=] approval,
 			or fulfill the criteria for [[#streamlined-update]].
 
 		<li>
@@ -3169,7 +3170,7 @@ Updating Mature Publications on the Recommendation Track</h4>
 	</ul>
 
 	There is usually a formal review meeting
-	to ensure the requirements have been met before [=Director=]'s approval is given.
+	to ensure the requirements have been met before [=Team=]'s approval is given.
 
 	Note: [=Update request=] approval is expected to be fairly simple
 	compared to getting approval for a [=transition request=].
@@ -3500,7 +3501,7 @@ Transitioning to Proposed Recommendation</h4>
 	<ul>
 		<li>
 			<em class="rfc2119">must</em> show [=adequate implementation experience=]
-			except where an exception is approved by the [=Director=],
+			except where an exception is approved by the [=Team=],
 		<li>
 			<em class="rfc2119">must</em> show that the document has received [=wide review=],
 
@@ -3524,7 +3525,7 @@ Transitioning to Proposed Recommendation</h4>
 			without republishing the specification as a [=Candidate Recommendation Snapshot=].
 	</ul>
 
-	The Director:
+	The [=Team=]:
 
 	<ul>
 		<li>
@@ -3537,7 +3538,9 @@ Transitioning to Proposed Recommendation</h4>
 			<em class="rfc2119">may</em> approve a [=Proposed Recommendation=]
 			with minimal <a href="#implementation-experience">implementation experience</a>
 			where there is a compelling reason to do so.
-			In such a case, the [=Director=] <em class="rfc2119">should</em> explain the reasons for that decision.
+			In such a case, the [=Team=] <em class="rfc2119">must</em> explain the reasons for that decision,
+			and that information <em class=rfc2119>must</em> be included in the [=Call for Review=]
+			proposing advancement to [=W3C Recommendation=].
 	</ul>
 
 	Since a [=W3C Recommendation=] <em class="rfc2119">must not</em> include any [=substantive changes=]
@@ -3595,7 +3598,7 @@ Transitioning to W3C Recommendation</h4>
 
 		<li>
 			If there was any [=dissent=] in Advisory Committee reviews,
-			the [=Director=] <em class="rfc2119">must</em> publish the substantive content of the dissent
+			the [=Team=] <em class="rfc2119">must</em> publish the substantive content of the dissent
 			to W3C and the general public,
 			and <em class="rfc2119">must</em> [=formally address=] the comment
 			at least 14 days before publication as a [=W3C Recommendation=].
@@ -3878,7 +3881,7 @@ Process for Rescinding, Obsoleting, Superseding, Restoring a Recommendation</h5>
 	superseding,
 	or restoring
 	a [=Recommendation=] can be initiated
-	either by a request from the [=Director=]
+	either by a request from the [=Team=]
 	or via a request from any of the following:
 
 	<ul>
@@ -3906,7 +3909,7 @@ Process for Rescinding, Obsoleting, Superseding, Restoring a Recommendation</h5>
 	obsolete,
 	supersede,
 	or restore
-	a [=Recommendation=] the [=Director=] <em class="rfc2119">must</em>:
+	a [=Recommendation=] the [=Team=] <em class="rfc2119">must</em>:
 
 	<ul>
 		<li>
@@ -3949,7 +3952,7 @@ Process for Rescinding, Obsoleting, Superseding, Restoring a Recommendation</h5>
 	</ul>
 
 	If there was any [=dissent=] in the [=Advisory Committee review=],
-	the [=Director=] <em class="rfc2119">must</em> publish
+	the [=Team=] <em class="rfc2119">must</em> publish
 	the substantive content of the dissent to W3C
 	<strong>and the public</strong>,
 	and <em class="rfc2119">must</em> [=formally address=] the dissent
@@ -3957,7 +3960,7 @@ Process for Rescinding, Obsoleting, Superseding, Restoring a Recommendation</h5>
 	before publication as an [=Obsolete Recommendation|Obsolete=] or [=Rescinded Recommendation=].
 
 	The <a href="#AC">Advisory Committee</a> <em class="rfc2119">may</em> initiate an [=Advisory Committee Appeal=]
-	of the [=Director=]'s decision.
+	of the [=Team=]'s decision.
 
 	W3C <em class="rfc2119">must</em> publish an [=Obsolete Recommendation|Obsolete=] or [=Rescinded Recommendation=]
 	with up to date status.

--- a/index.bs
+++ b/index.bs
@@ -2788,13 +2788,12 @@ The W3C Recommendation Track</h3>
 
 	W3C <em class="rfc2119">may</em> <a href="#tr-end">end work on a technical report</a> at any time.
 
-	The [=Team=] <em class="rfc2119">may</em> [=Team Decision|decide=]
+	As described in [[#transition-reqs]],
+	the [=Team=] <em class="rfc2119">may</em> [=Team Decision|decide=]
 	to decline a request to advance in maturity level,
-	requiring a [=Working Group=] to conduct further work.
-	The [=Team=] <em class="rfc2119">must</em> inform the <a href="#AC">Advisory Committee</a>
-	and [=Working Group=] [=Chairs=] when a [=Working Group=]'s request
-	for a specification to advance in maturity level is declined
-	and the specification is returned to a [=Working Group=] for further work.
+	and return the specification to a [=Working Group=] for further work,
+	if it determines that the requirements for advancement
+	have not been met.
 
 <h4 id="maturity-levels">
 Maturity Levels on the Recommendation Track</h4>
@@ -3068,6 +3067,12 @@ Advancement on the Recommendation Track</h4>
 
 		<li>
 			<em class="rfc2119">must </em> obtain [=Team=] approval.
+			[=Team=] approval (a [=Team decision=])
+			<em class=rfc2119>must</em> be withheld if any Process requirements are not met
+			or if there remain any unresolved Formal Objections.
+			If the [=Team=] rejects a [=Transition Request=]
+			it <em class=rfc2119>must</em> indicate its rationale
+			to the [=Advisory Committee=] and the [=Working Group=].
 
 		<li>
 			<em class="rfc2119 ">must</em> publicly document all new features
@@ -3120,7 +3125,7 @@ Updating Mature Publications on the Recommendation Track</h4>
 	Certain requests to re-publish a specification
 	within its current maturity level
 	(called <dfn export>Update Requests</dfn>)
-	require [=Team=] approval.
+	require extra verification.
 	For such [=update requests=], the Working Group:
 
 	<ul>
@@ -3133,6 +3138,14 @@ Updating Mature Publications on the Recommendation Track</h4>
 		<li>
 			<em class="rfc2119">must </em> obtain [=Team=] approval,
 			or fulfill the criteria for [[#streamlined-update]].
+			[=Team=] approval (a [=Team decision=]),
+			<em>should</em> be withheld if any Process requirements are not met,
+			and <em class=rfc2119>may</em> be withheld in consideration of unresolved Formal Objections.
+			If the [=Team=] rejects an [=Update Request=],
+			it must indicate its rationale to the [=Working Group=].
+			If it waives any Process requirements,
+			it must indicate its rationale to the [=AC=].
+
 
 		<li>
 			<em class="rfc2119">must</em> provide public documentation of any [=Formal Objections=].
@@ -3499,7 +3512,7 @@ Transitioning to Proposed Recommendation</h4>
 	<ul>
 		<li>
 			<em class="rfc2119">must</em> show [=adequate implementation experience=]
-			except where an exception is approved by the [=Team=],
+			except where an exception is approved by a [=Team Decision=],
 		<li>
 			<em class="rfc2119">must</em> show that the document has received [=wide review=],
 

--- a/index.bs
+++ b/index.bs
@@ -2790,9 +2790,7 @@ The W3C Recommendation Track</h3>
 
 	The [=Team=] <em class="rfc2119">may</em> [=Team Decision|decide=]
 	to decline a request to advance in maturity level,
-	requiring a [=Working Group=] to conduct further work,
-	and <em class="rfc2119">may</em> require
-	the specification to return to a lower <a href="#maturity-levels">maturity level</a>.
+	requiring a [=Working Group=] to conduct further work.
 	The [=Team=] <em class="rfc2119">must</em> inform the <a href="#AC">Advisory Committee</a>
 	and [=Working Group=] [=Chairs=] when a [=Working Group=]'s request
 	for a specification to advance in maturity level is declined
@@ -3787,6 +3785,18 @@ Incorporating Candidate Amendments</h5>
 	can be incorporated into the normative [=Recommendation=] text.
 	(Thus if incorporation of a [=proposed amendment=] is postponed,
 	it may need to be included in multiple Last Calls for Review of Proposed Amendments.)
+
+<h4 id=rec-track-regression>
+Regression on the Recommendation Track</h4>
+
+	A [=Working Group=] may republish a [=Recommendation-track=] [=technical report=] at a lower <a href="#maturity-levels">maturity level</a>
+	by fulfilling the requirements to transition to that maturity level,
+	as described above.
+
+	Additionally,
+	the [=Team=] <em class="rfc2119">may</em> return
+	the [=technical report=] to a lower <a href="#maturity-levels">maturity level</a>
+	in response to [=wide review=] or a [=formal objection=].
 
 <h4 id="tr-end">
 Retiring Recommendation Track Documents</h4>

--- a/index.bs
+++ b/index.bs
@@ -3794,6 +3794,7 @@ Regression on the Recommendation Track</h4>
 	as described above.
 
 	Additionally,
+	with the approval of the [=TAG=] and the [=AB=]
 	the [=Team=] <em class="rfc2119">may</em> return
 	the [=technical report=] to a lower <a href="#maturity-levels">maturity level</a>
 	in response to [=wide review=] or a [=formal objection=].

--- a/index.bs
+++ b/index.bs
@@ -2789,9 +2789,8 @@ The W3C Recommendation Track</h3>
 	W3C <em class="rfc2119">may</em> <a href="#tr-end">end work on a technical report</a> at any time.
 
 	As described in [[#transition-reqs]],
-	the [=Team=] <em class="rfc2119">may</em> [=Team Decision|decide=]
-	to decline a request to advance in maturity level,
-	and return the specification to a [=Working Group=] for further work,
+	the [=Team=] will decline a request to advance in maturity level
+	and return the specification to a [=Working Group=] for further work
 	if it determines that the requirements for advancement
 	have not been met.
 


### PR DESCRIPTION
Note that:
* transitions on TR are not initiated by the Team
* there's always an opportunity to object if the Team does get it wrong

Therefore, even though the criteria that we're asking the Team to judge are somewhat fuzzy, this is not a particularly strong delegation of authority to the Team. (We can also consider clarifying the fuzzy criteria in /guide or in a separate issue.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/586.html" title="Last updated on Nov 9, 2021, 6:30 AM UTC (a947b6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/586/15d3ab4...frivoal:a947b6c.html" title="Last updated on Nov 9, 2021, 6:30 AM UTC (a947b6c)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/586.html" title="Last updated on Jul 13, 2022, 2:56 PM UTC (4387d8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/586/15d3ab4...frivoal:4387d8c.html" title="Last updated on Jul 13, 2022, 2:56 PM UTC (4387d8c)">Diff</a>