### PR TITLE
editorial: rm undefined COO from informal Note

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1955,7 +1955,7 @@ Consensus</h4>
 	or <a href="#distributed-meeting">distributed</a>)
 	as well as through <a href=#discussion-archiving>persistent text-based discussions</a>.
 
-	Note: The Director, CEO, and COO have the role of
+	Note: The Director and CEO have the role of
 	assessing consensus within the Advisory Committee.
 
 	The following terms are used in this document


### PR DESCRIPTION
remove "COO" from a list in an informal Note. "COO" is not defined in the document either (in contrast, CEO is in the glossary), so this seems like it was a mistake that made it past review, and thus should be removed from a non-normative Note. if there's an actual use-case for adding "COO" to the Process, that should be raised as a separate issue for proper definition and consideration.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/pull/614.html" title="Last updated on Aug 1, 2022, 8:53 PM UTC (d19ccf5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/614/e4481e8...d19ccf5.html" title="Last updated on Aug 1, 2022, 8:53 PM UTC (d19ccf5)">Diff</a>