### PR TITLE
Adopt the W3C Council for handing Formal objections and related matters

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2338,6 +2338,11 @@ Extraordinary Delegation</h5>
 	(i.e., at least twice as many votes in favor as against).
 	Delegation in such cases cannot be later revoked.
 
+	The [=Team=] <em class=rfc2119>must</em> inform the [=Advisory Committee=]
+	when a [=Formal Objection=] has been delegated,
+	and to whom it has been delegated.
+
+
 <h5 id=council-participation>
 Council Participation, Dismissal, and Renunciation</h5>
 

--- a/index.bs
+++ b/index.bs
@@ -2295,7 +2295,7 @@ Investigation and Mediation by the Team</h4>
 
 	Otherwise,
 	upon concluding that consensus cannot be found,
-	and within at most 90 days of the [=Formal Objection=] being registered,
+	and no later than 90 days after the [=Formal Objection=] being registered,
 	the [=Team=] <em class=rfc2119>must</em> initiate formation of the [=W3C Council=],
 	which should be <a href="#council-convention">convened</a> within 45 days of being initiated.
 	Concurrently, it must prepare a report for the [=Council=]

--- a/index.bs
+++ b/index.bs
@@ -2414,14 +2414,20 @@ Council Chairing</h5>
 Council Deliberations</h5>
 
 	Having reviewed the information gathered by the [=Team=],
-	and after sufficient sufficient deliberation,
+	the Council <em class=rfc2119>may</em> conduct additional research or analysis,
+	or request additional information or interviews from anyone,
+	including the Team.
+
+	The Council <em class=rfc2119>may</em>
+	further attempt to broker consensus,
+	which, if successful, disposes the formal objection.
+
+	Otherwise,
+	after sufficient deliberation,
 	the [=W3C Council=] decides whether to
 	<dfn>sustain</dfn> or <dfn>overrule</dfn> the objection.
 	When [=sustaining=] an objection,
 	it <em class=rfc2199>should</em> recommend a way forward.
-
-	Individuals registering [=Formal Objections=] often support their reasoning
-	with several arguments.
 	The [=W3C Council=] <em class=rfc2119>may</em> [=overrule=] the [=Formal Objection=]
 	even if it agrees with some of the supportive arguments.
 

--- a/index.bs
+++ b/index.bs
@@ -2381,7 +2381,17 @@ Council Participation, Dismissal, and Renunciation</h5>
 	falling back to a vote if that fails.
 	The chair must be a member of the [=W3C Council=].
 
-	Having reviewed the information gathered by the [=Team=] and its recommendation,
+	In extraordinary cases,
+	if the [=Council=] determines that it would not be the appropriate body to handle a particular [=Formal Objection=],
+	it <em class=rfc2119>may</em> decide by a ⅔ supermajority vote
+	(i.e. twice as many votes in favor as against)
+	to delegate the decision for that specific [=Formal Objection=]
+	to the W3C Board of Directors,
+	to an officer of its corporation (such as the Legal Counsel),
+	or to one or more specific individuals from the [=Team=].
+	Delegation in such cases cannot be later revoked.
+
+	Otherwise, having reviewed the information gathered by the [=Team=] and its recommendation,
 	and after sufficient sufficient deliberation,
 	the [=W3C Council=] decides whether to
 	<dfn>sustain</dfn> or <dfn>overrule</dfn> the objection.

--- a/index.bs
+++ b/index.bs
@@ -747,7 +747,7 @@ Role of the Advisory Committee</h4>
 	[=Advisory Committee representatives=] <em class="rfc2119">may</em> initiate
 	an <a href="#ACAppeal">Advisory Committee Appeal</a>
 	of a [=W3C decision=]
-	or [=Director=]'s decision.
+	or [=Team=]'s decision.
 
 	See also the additional roles of [=Advisory Committee representatives=]
 	described in the W3C Patent Policy [[PATENT-POLICY]].
@@ -878,14 +878,18 @@ Role of the Advisory Board</h5>
 	soliciting Member comments on such issues,
 	and proposing actions to resolve these issues.
 	The Advisory Board manages the <a href="#GAProcess">evolution of the Process Document</a>.
-	The Advisory Board hears a <a href="#SubmissionNo">Submission Appeal</a>
-	when a Member Submission is rejected
-	for reasons unrelated to Web architecture;
-	see also the <a href="#TAG">TAG</a>.
+	Together with the [=CEO=] and the members of the [=TAG=],
+	members of the [=Advisory Board=] hear and adjudicate on <a href="#SubmissionNo">Submission Appeals</a>,
+	[=Chair Decision Appeals=],
+	[=Group Decision Appeals=],
+	and [=Formal Objections=].
 
 	The [=Advisory Board=] is <strong>not</strong> a board of directors
 	and has no decision-making authority within W3C;
 	its role is strictly advisory.
+
+	Note: While the [=AB=] as such does not have decision-making authority,
+	its members do when seating as part of the [=W3C Council=].
 
 	Details about the Advisory Board
 	(e.g., the list of Advisory Board participants,
@@ -951,9 +955,11 @@ Role of the Technical Architecture Group</h5>
 			to help coordinate cross-technology architecture developments inside and outside W3C.
 	</ol>
 
-	The [=TAG=] hears a <a href="#SubmissionNo">Submission Appeal</a>
-	when a Member Submission is rejected for reasons related to Web architecture;
-	see also the <a href="#AB">Advisory Board</a>.
+	Together with the [=CEO=] and members of the [=AB=],
+	the members of the [=TAG=] hear and adjudicate on <a href="#SubmissionNo">Submission Appeal s</a>,
+	[=Chair Decision Appeals=],
+	[=Group Decision Appeals=],
+	and [=Formal Objections=].
 
 	The [=TAG=]'s scope is limited to technical issues about Web architecture.
 	The TAG <em class="rfc2119">should not</em> consider
@@ -1971,8 +1977,8 @@ Types of Decisions</h3>
 	(also known as group “resolutions”).
 
 	A <dfn id="def-w3c-decision">W3C decision</dfn> is one
-	where the [=Director=] decides,
-	after exercising the role of assessing consensus of the W3C Community after an [=Advisory Committee review=].
+	where the [=Team=]
+	assesses consensus of the W3C Community after an [=Advisory Committee review=].
 
 <h3 id=consensus-building>
 Consensus Building</h3>
@@ -2220,17 +2226,16 @@ Reopening a Decision When Presented With New Information</h3>
 [=Chair Decision=] and [=Group Decision=] Appeals</h3>
 
 	When group participants believe that their concerns are not being duly considered by the group or the [=Chair=],
-	they <em class="rfc2119">may</em> ask the <a href="#def-Director">Director</a>
-	(for representatives of a Member organization, via their Advisory Committee representative)
-	to confirm or deny the decision.
+	they <em class="rfc2119">may</em> ask that the decision be confirmed or denied
+	(for representatives of a Member organization, via their Advisory Committee representative).
 	This is a <dfn export id="wg-decision-appeal">Group Decision Appeal</dfn>
 	or a <dfn export id="chair-decision-appeal">Chair Decision Appeal</dfn>.
 	The participants <em class="rfc2119">should</em> also make their requests known
 	to the <a href="#TeamContact">Team Contact</a>.
-	The Team Contact <em class="rfc2119">must</em> inform the Director
-	when a group participant has raised concerns about due process.
+	The Team Contact <em class="rfc2119">must</em> inform the [=CEO=]
+	when a group participant has also raised concerns about due process.
 
-	Any requests to the Director to confirm a decision
+	Any requests to confirm a decision
 	<em class="rfc2119">must</em> include a summary of
 	the issue (whether technical or procedural),
 	decision,
@@ -2239,20 +2244,24 @@ Reopening a Decision When Presented With New Information</h3>
 	rationales,
 	and decisions <em class="rfc2119">must</em> be recorded.
 
+	The procedure for handling [=Group Decision Appeals=]
+	and [=Chair Decision Appeals=]
+	is the same as for [=Formal Objections=].
+
 	Procedures for <a href="#ACAppeal">Advisory Committee appeals</a> are described separately.
 
 <h3 id="WGArchiveMinorityViews">
-Recording and Reporting Formal Objections</h3>
+Registering Formal Objections</h3>
 
 	In the W3C process,
 	an individual <em class="rfc2119">may</em> register a Formal Objection to a decision.
 	A <dfn id="FormalObjection">Formal Objection</dfn> to a group decision
-	is one that the reviewer requests that the Director consider
+	is one that the reviewer requests that the W3C consider
 	as part of evaluating the related decision
 	(e.g., in response to a <a href="#rec-advance">request to advance</a> a technical report).
 
-	Note: In this document, the term “Formal Objection” is used to emphasize this process implication:
-	Formal Objections receive Director consideration.
+	Note: In this document, the term [=Formal Objection=] is used to emphasize this process implication:
+	Formal Objections receive formal consideration and a formal response.
 	The word “objection” used alone has ordinary English connotations.
 
 	An individual who registers a [=Formal Objection=] <em class="rfc2119">should</em> cite technical arguments
@@ -2263,6 +2272,152 @@ Recording and Reporting Formal Objections</h3>
 
 	A record of each [=Formal Objection=] <em class="rfc2119">must</em> be <a href="#confidentiality-change">publicly available</a>.
 	A Call for Review (of a document) to the Advisory Committee <em class="rfc2119">must</em> identify any [=Formal Objections=].
+
+<h3 id=addressing-fo>
+Addressing Formal Objections</h3>
+
+<h4 id=team-fo-mediation>
+Investigation and Mediation by the Team</h4>
+
+	The [=Team=] considers the [=Formal objection=],
+	researches the question,
+	interviews parties,
+	and so on,
+	to make sure the problem and the various viewpoints are well understood,
+	and to the extent possible,
+	to arrive at a recommended disposition.
+	If the [=Team=] can resolve the issue
+	to the satisfaction of the individual that filed the [=Formal Objection=],
+	the individual withdraws the objection and the disposition process terminates.
+
+	Otherwise,
+	within at most 45 days of the [=Formal Objection=] being registered,
+	the [=Team=] must present its conclusions (or lack thereof)
+	to the [=W3C Council=].
+
+<h4 id=council>
+The W3C Council</h4>
+
+	The <dfn local-lt="Council">W3C Council</dfn> consists of the following members,
+	with the exception of any who are [=dismissed=] or who formally [=renounce=] their position:
+	* the [=CEO=]
+	* the members of the [=Advisory Board=]
+	* the members of the [=Technical Architecture Group=]
+
+	Participation in the [=W3C Council=] <em class=rfc2119>must not</em> require attendance of [=face-to-face meetings=].
+
+	A distinct instance of the [=W3C Council=] is convened for each decision being appealed or objected to.
+	Membership of an instance the [=Council=] is be fixed at formation,
+	and is not changed by any [=AB=] or [=TAG=] elections
+	occurring before that Council has reached a conclusion.
+	However, if participation in a [=Council=] falls so low as to hinder effective and balanced deliberations,
+	the [=Chair of the Council=] <em class="rfc2119">should</em> dissolve the [=Council=]
+	and call for a new one to be convened.
+
+	A [=Team=] member is assigned to support the Council.
+
+<h5 id=council-participation>
+Council Participation, Dismissal, and Renunciation</h5>
+
+	In order to apply consistent criteria,
+	the potential Council members decide collectively
+	which reasons against service
+	rise to a sufficient level for a potential member to be <dfn lt="dismissed | dismiss | dismissal">dismissed</dfn>.
+	No-one is automatically dismissed,
+	and individual recusal is not used in the Council.
+	[=Dismissal=] applies to an individual person in the context of a specific Council,
+	and should be used rarely in order to preserve the greatest diversity on the Council.
+
+	Note: The Council is a deliberative body whose purpose is
+	to find the best way forward for the Web and for W3C.
+	It is not a judicial body tasked with determining right or wrong.
+
+	The [=Team=] <em class=rfc2119>must</em> draft a list of potential [=Council=] members,
+	with annotations of possible reasons for dismissal against each one.
+	The W3C community,
+	including members and team, and potential council members,
+	<em class=rfc2119>must</em> be given an opportunity to contribute possible reasons to this list.
+	Affected members <em class=rfc2119>must</em> be given
+	an opportunity to respond to such comments about themselves.
+	The [=Team=] may report comments verbatim
+	or may paraphrase them while preserving their intent;
+	they may also elide inappropriate comments,
+	such as any that violate applicable laws or the [[CEPC]].
+
+	Before the Council forms,
+	the [=Team=] presents the entire list of potential members
+	and collected reasons and responses
+	to the potential Council members.
+	They then consider for each potential member
+	whether that individual's participation
+	would compromise the integrity of the Council decision,
+	and vote whether to dismiss that potential member.
+	No one is allowed to vote on their own dismissal;
+	each dismissal is decided by simple majority of those not abstaining.
+
+	Note: Since dismissal is individual,
+	when the decision being objected to was made by the [=TAG=] or [=AB=] acting as a body,
+	the entire [=TAG=] or [=AB=] is not expected or required to be dismissed.
+
+	An individual <em class=rfc2119>may</em> also <dfn lt="renounce | renunciation | renounces">renounce</dfn> their seat on the Council, for strong reason,
+	such as being forbidden by their employer to serve. The individual chooses the extent to which they explain
+	their renunciation.
+	Renunciation is disqualification from participation,
+	not abstention,
+	and <em class=rfc2119>should not</em> be used
+	to excuse an absence of participation.
+
+	Any person who has been [=dismissed=]
+	or who [=renounces=] their seat
+	does not receive [=Council=] materials,
+	take part in its deliberations,
+	help in the determination of consensus,
+	or vote.
+	The [=W3C Council=] <em class=rfc2110>may</em> still solicit and hear their testimony,
+	as they can of anyone else in the W3C community.
+
+	The <dfn local-lt="Chair of the Council">Chair of the W3C Council</dfn> for a particular topic is chosen by its members,
+	by consensus if possible,
+	falling back to a vote if that fails.
+	The chair must be a member of the [=W3C Council=].
+
+	Having reviewed the information gathered by the [=Team=] and its recommendation,
+	and after sufficient sufficient deliberation,
+	the [=W3C Council=] decides whether to
+	<dfn>sustain</dfn> or <dfn>overrule</dfn> the objection.
+
+	Decision of the [=W3C Council=] should be unanimous.
+	If despite careful deliberation
+	the [=W3C Council=] is unable to reach consensus,
+	the [=Chair of the W3C Council=] may instead resort to voting.
+	In that case,
+	the decision is made by simple majority,
+	with the [=Chair of the W3C Council=] breaking ties.
+
+	If the [=W3C Council=] is unable to come to a conclusion within 90 days of being initially convened for a particular topic,
+	the [=Chair of the W3C Council=] <em class=rfc2119>must</em> inform the [=AC=] of this delay
+	and of the status of the discussions.
+	The [=Chair of the W3C Council=] <em class=rfc2119>may</em> additionally make this report <a href="#confidentiality-levels">public</a>.
+
+	The deliberations of the [=W3C Council=] are confidential to the [=W3C Council=].
+	Decisions of the [=W3C Council=] <em class=rfc2119>must</em> have the same level of confidenntiality
+	as the object of the [=Formal Objection=].
+	A rationale supporting the decision <em class=2119>must</em> be provided as well.
+	In the case of non-unanimous decisions,
+	members of the [=W3C Council=] who disagree with the decision
+	<em class=rfc2119>may</em> write a <dfn>Minority Opinion</dfn>
+	explaining the reason for their disagreement.
+	[=Minority Opinions=] <em class=rfc2119>must</em> be included in the announcement of the decision.
+
+	Individuals registering [=Formal Objections=] often support their reasoning
+	with several arguments.
+	In the rationale explaining its decision,
+	the [=W3C Council=] must address each point.
+	The [=W3C Council=] <em class=rfc2119>may</em> [=overrule=] the [=Formal Objection=]
+	even if it agrees with some of the supportive arguments.
+
+	[=Advisory Committee representatives=] may initiate an [=Advisory Committee Appeal=]
+	of the [=W3C Council=]'s decision.
 
 <h3 id="ACReview">
 Advisory Committee Reviews</h3>
@@ -2316,11 +2471,11 @@ Start of a Review Period</h4>
 After the Review Period</h4>
 
 	After the review period,
-	the [=Director=] <em class="rfc2119">must</em> announce
+	the [=Team=] <em class="rfc2119">must</em> announce
 	to the [=Advisory Committee=]
 	the level of support for the proposal
 	([=consensus=] or [=dissent=]).
-	The [=Director=] <em class="rfc2119">must</em> also indicate
+	The [=Team=] <em class="rfc2119">must</em> also indicate
 	whether there were any [=Formal Objections=],
 	with attention to <a href="#confidentiality-change">changing confidentiality level</a>.
 	This [=W3C decision=] is generally one of the following:
@@ -2352,7 +2507,7 @@ After the Review Period</h4>
 	The [=Advisory Committee=] <em class="rfc2119">should not</em> expect an announcement
 	sooner than <span class="time-interval">two weeks</span> after the end of a review period.
 	If, after <span class="time-interval">three weeks</span>, the outcome has not been announced,
-	the [=Director=] <em class="rfc2119">should</em> provide the [=Advisory Committee=] with an update.
+	the [=Team=] <em class="rfc2119">should</em> provide the [=Advisory Committee=] with an update.
 
 <h3 id="ACVotes">
 Advisory Committee Votes</h3>
@@ -2377,6 +2532,7 @@ Appeal by Advisory Committee Representatives</h3>
 	and the Process document.
 
 	[=Advisory Committee representatives=] <em class="rfc2119">may</em> also initiate an appeal
+	for decisions of the [=W3C Council=], and
 	for certain decisions that do not involve an [=Advisory Committee review=].
 	These cases are identified in the sections
 	which describe the requirements for the decision
@@ -2389,7 +2545,7 @@ Appeal by Advisory Committee Representatives</h3>
 	an [=appeal=] <em class="rfc2119">must</em> be initiated within <span class="time-interval">three weeks</span> of the decision.
 
 	An [=Advisory Committee representative=] initiates an [=appeal=] by sending a request to the [=Team=].
-	The request should say “I appeal this Director's Decision”
+	The request should say “I appeal this Decision”
 	and identify the decision.
 	Within one week the [=Team=] <em class="rfc2119">must</em> announce the appeal process
 	to the [=Advisory Committee=]
@@ -2400,8 +2556,8 @@ Appeal by Advisory Committee Representatives</h3>
 	5% or more of the [=Advisory Committee=] support the appeal request,
 	the Team <em class="rfc2119">must</em> organize an appeal vote
 	asking the [=Advisory Committee=]
-	“Do you approve of the Director's Decision?”
-	together with links to the [=Director=]'s decision and the appeal support.
+	“Do you approve of the Decision?”
+	together with links to the decision and the appeal support.
 
 	The ballot <em class="rfc2119">must</em> allow for three possible responses:
 	“Approve”,

--- a/index.bs
+++ b/index.bs
@@ -2385,6 +2385,8 @@ Council Participation, Dismissal, and Renunciation</h5>
 	and after sufficient sufficient deliberation,
 	the [=W3C Council=] decides whether to
 	<dfn>sustain</dfn> or <dfn>overrule</dfn> the objection.
+	When [=sustaining=] an objection,
+	it <em class=rfc2199>should</em> recommend a way forward.
 
 	Decision of the [=W3C Council=] should be unanimous.
 	If despite careful deliberation

--- a/index.bs
+++ b/index.bs
@@ -2442,10 +2442,17 @@ Council Deliberations</h5>
 	after sufficient deliberation,
 	the [=W3C Council=] decides whether to
 	<dfn>sustain</dfn> or <dfn>overrule</dfn> the objection.
-	When [=sustaining=] an objection,
-	it <em class=rfc2199>should</em> recommend a way forward.
 	The [=W3C Council=] <em class=rfc2119>may</em> [=overrule=] the [=Formal Objection=]
 	even if it agrees with some of the supportive arguments.
+
+	<p id=fo-mitigations>
+	When [=sustaining=] an objection,
+	it <em class=rfc2199>should</em> recommend a way forward.
+	If the overturned decision has already had consequences
+	(e.g., if the objection concerns material already in a published document)
+	the Council <em class=rfc2119>should</em> suggest how these consequences might be mitigated.
+	The [=Team=] is responsible for making sure that adequate mitigations are enacted in a timely fashion;
+	and the [=Formal Objection=] is not considered fully addressed until then.
 
 	The Council <em class=rfc2119>may</em> form sub-groups for deliberation,
 	who may return with a recommendation,
@@ -2484,6 +2491,7 @@ Council Decision Report</h5>
 	* <em class=rfc2119>must</em> provide a rationale supporting the decision,
 		which <em class=rfc2119>should</em> address each argument raised in the Formal Objection(s).
 	* <em class=rfc2119>must</em> include any recommendation decided by the [=Council=].
+	* if the [=Formal Objection=] has been sustained, <em class=rfc2119>should</em> include any suggested <a href="#fo-mitigations">mitigations</a>.
 	* <em class=rfc2119>must</em> include the [=Minority Opinion=](s), if any.
 	* <em class=rfc2119>must</em> report the names of those who were [=dismissed=] or [=renounced=] their seat as well as those who were qualified to serve.
 	* <em class=rfc2119>must</em> report the names of the individuals who participated in the final decision.
@@ -3362,7 +3370,8 @@ Advancement on the Recommendation Track</h4>
 			<em class="rfc2119">must </em> obtain [=Team=] verification.
 			[=Team=] verification (a [=Team decision=])
 			<em class=rfc2119>must</em> be withheld if any Process requirements are not met
-			or if there remain any unresolved Formal Objections.
+			or if there remain any unresolved Formal Objections,
+			or if the document does not adequately reflect all relevant decisions of the [=W3C Council=] (or its delegates).
 			If the [=Team=] rejects a [=Transition Request=]
 			it <em class=rfc2119>must</em> indicate its rationale
 			to the [=Advisory Committee=] and the [=Working Group=].
@@ -3433,7 +3442,8 @@ Updating Mature Publications on the Recommendation Track</h4>
 			or fulfill the criteria for [[#streamlined-update]].
 			[=Team=] verification (a [=Team decision=]),
 			<em>should</em> be withheld if any Process requirements are not met,
-			and <em class=rfc2119>may</em> be withheld in consideration of unresolved Formal Objections.
+			and <em class=rfc2119>may</em> be withheld in consideration of unresolved Formal Objections
+			or if the document does not adequately reflect all relevant decisions of the [=W3C Council=] (or its delegates).
 			If the [=Team=] rejects an [=Update Request=],
 			it must indicate its rationale to the [=Working Group=].
 			If it waives any Process requirements,

--- a/index.bs
+++ b/index.bs
@@ -2474,8 +2474,12 @@ Council Decision Report</h5>
 	* <em class=rfc2119>must not</em> report individual votes or vote totals, if any vote was held.
 	* <em class=rfc2119>must not</em> attribute any point to any individual on the Council.
 
-	Decisions of the [=W3C Council=] <em class=rfc2119>must</em> have the same level of confidentiality
-	as the object of the [=Formal Objection=].
+	The [=Team=] <em class=rfc2119>must</em> maintain a public page on the W3C website
+	indexing all completed [=Council Reports=].
+	If a Council decision is later overturned by an [=AC Appeal=],
+	this <em class=rfc2119>must</em> also be mentioned.
+	[=Council Reports=] <em class=rfc2119>must</em> have the same level of confidentiality
+	as the [=Formal Objection=].
 
 <h5 id=council-appeals>
 Appealing Council Decisions</h5>

--- a/index.bs
+++ b/index.bs
@@ -2388,6 +2388,8 @@ Council Participation, Dismissal, and Renunciation</h5>
 	When [=sustaining=] an objection,
 	it <em class=rfc2199>should</em> recommend a way forward.
 
+	The Council <em class=rfc2119>may</em> form subsets for deliberation and to return with a recommendation,
+	but the full Council issues the final decision.
 	Decision of the [=W3C Council=] should be unanimous.
 	If despite careful deliberation
 	the [=W3C Council=] is unable to reach consensus,

--- a/index.bs
+++ b/index.bs
@@ -2304,11 +2304,15 @@ Investigation and Mediation by the Team</h4>
 <h4 id=council>
 The W3C Council</h4>
 
+	The <dfn export local-lt="Council">W3C Council</dfn> is the body convened to resolve [=Formal Objections=]
+	by combining the capabilities and perspectives of the [=AB=], the [=TAG=], and the [=Team=],
+	and is tasked with doing so in the best interests of the Web and W3C.
+
 <h5 id=council-composition>
 Council Composition</h5>
 
-	The <dfn local-lt="Council">W3C Council</dfn> consists of the following members,
-	with the exception of any who are [=dismissed=] or who formally [=renounce=] their position:
+	The [=W3C Council=] consists of the following members,
+	with the exception of any who are [=dismissed=] or who formally [=renounce=] their positions:
 	* the [=CEO=]
 	* the members of the [=Advisory Board=]
 	* the members of the [=Technical Architecture Group=]

--- a/index.bs
+++ b/index.bs
@@ -2222,56 +2222,45 @@ Reopening a Decision When Presented With New Information</h3>
 	that a decision has been reopened,
 	and <em class="rfc2119">must</em> do so upon request from a group participant.
 
-<h3 id="WGAppeals">
-[=Chair Decision=] and [=Group Decision=] Appeals</h3>
-
-	When group participants believe that their concerns are not being duly considered by the group or the [=Chair=],
-	they <em class="rfc2119">may</em> ask that the decision be confirmed or denied
-	(for representatives of a Member organization, via their Advisory Committee representative).
-	This is a <dfn export id="wg-decision-appeal">Group Decision Appeal</dfn>
-	or a <dfn export id="chair-decision-appeal">Chair Decision Appeal</dfn>.
-	The participants <em class="rfc2119">should</em> also make their requests known
-	to the <a href="#TeamContact">Team Contact</a>.
-	The Team Contact <em class="rfc2119">must</em> inform the [=CEO=]
-	when a group participant has also raised concerns about due process.
-
-	Any requests to confirm a decision
-	<em class="rfc2119">must</em> include a summary of
-	the issue (whether technical or procedural),
-	decision,
-	and rationale for the objection.
-	All counter-arguments,
-	rationales,
-	and decisions <em class="rfc2119">must</em> be recorded.
-
-	The procedure for handling [=Group Decision Appeals=]
-	and [=Chair Decision Appeals=]
-	is the same as for [=Formal Objections=].
-
-	Procedures for <a href="#ACAppeal">Advisory Committee appeals</a> are described separately.
-
-<h3 id="WGArchiveMinorityViews">
+<h3 id="registering-objections" oldids="WGArchiveMinorityViews, WGAppeals, wg-decision-appeal, chair-decision-appeal">
 Registering Formal Objections</h3>
 
 	In the W3C process,
-	an individual <em class="rfc2119">may</em> register a Formal Objection to a decision.
-	A <dfn id="FormalObjection">Formal Objection</dfn> to a group decision
-	is one that the reviewer requests that the W3C consider
-	as part of evaluating the related decision
-	(e.g., in response to a <a href="#rec-advance">request to advance</a> a technical report).
+	any individual <em class="rfc2119">may</em> appeal a decision
+	by registering a <dfn id="FormalObjection">Formal Objection</dfn> with the [=Team=]
+	when they believe that their concerns are not being duly considered.
+	Group participants <em class="rfc2119">should</em> inform
+	their <a href="#TeamContact">Team Contact</a> as well as the group's Chair(s).
+	The Team Contact <em class="rfc2119">must</em> inform the [=CEO=]
+	when a group participant has also raised concerns about due process.
 
 	Note: In this document, the term [=Formal Objection=] is used to emphasize this process implication:
 	Formal Objections receive formal consideration and a formal response.
-	The word “objection” used alone has ordinary English connotations.
+	The word “objection” used alone has its ordinary English connotations.
 
-	An individual who registers a [=Formal Objection=] <em class="rfc2119">should</em> cite technical arguments
+	A [=Formal Objection=]
+	<em class="rfc2119">must</em> include a summary of
+	the issue (whether technical or procedural),
+	the decision being appealed,
+	and the rationale for the objection.
+	It <em class="rfc2119">should</em> cite technical arguments
 	and propose changes that would remove the [=Formal Objection=];
 	these proposals <em class="rfc2119">may</em> be vague or incomplete.
 	[=Formal Objections=] that do not provide substantive arguments
 	or rationale are unlikely to receive serious consideration.
+	Counter-arguments,
+	rationales,
+	and decisions <em class="rfc2119">should</em> also be recorded.
 
-	A record of each [=Formal Objection=] <em class="rfc2119">must</em> be <a href="#confidentiality-change">publicly available</a>.
-	A Call for Review (of a document) to the Advisory Committee <em class="rfc2119">must</em> identify any [=Formal Objections=].
+	A record of each [=Formal Objection=] regarding a publicly-available document
+	<em class="rfc2119">must</em> be made <a href="#confidentiality-change">publicly available</a>.
+	A Call for Review to the Advisory Committee
+	<em class="rfc2119">must</em> identify any [=Formal Objections=]
+	related to that review.
+
+	Note: [=Formal Objections=] against matter in a [=technical report=]
+	are required to be addressed before <a href="#rec-advance">requesting advancement</a>
+	of the [=technical report=].
 
 	A [=Formal Objection=] filed during an [=Advisory Committee Review=]
 	is considered registered at the close of the review period.

--- a/index.bs
+++ b/index.bs
@@ -2398,6 +2398,11 @@ Council Participation, Dismissal, and Renunciation</h5>
 	the decision is made by simple majority,
 	with the [=Chair of the W3C Council=] breaking ties.
 
+	If the [=Council=] needs to resort to a vote,
+	and if two members of the council who share the same affiliation cast an identical ballot,
+	then their ballots count as a one vote,
+	not two.
+
 	If the [=W3C Council=] is unable to come to a conclusion within 90 days of being initially convened for a particular topic,
 	the [=Chair of the W3C Council=] <em class=rfc2119>must</em> inform the [=AC=] of this delay
 	and of the status of the discussions.

--- a/index.bs
+++ b/index.bs
@@ -2273,6 +2273,9 @@ Registering Formal Objections</h3>
 	A record of each [=Formal Objection=] <em class="rfc2119">must</em> be <a href="#confidentiality-change">publicly available</a>.
 	A Call for Review (of a document) to the Advisory Committee <em class="rfc2119">must</em> identify any [=Formal Objections=].
 
+	A [=Formal Objection=] filed during an [=Advisory Committee Review=]
+	is considered registered at the close of the review period.
+
 <h3 id=addressing-fo>
 Addressing Formal Objections</h3>
 
@@ -2291,10 +2294,12 @@ Investigation and Mediation by the Team</h4>
 	the individual withdraws the objection and the disposition process terminates.
 
 	Otherwise,
-	within at most 90 days of a [=Formal Objection=] being registered,
-	the [=Team=] <em class=rfc2119>must</em> initiate formation of the [=W3C Council=]
-	and prepare a report of its findings
-	and attempts to find consensus.
+	upon concluding that consensus cannot be found,
+	and within at most 90 days of the [=Formal Objection=] being registered,
+	the [=Team=] <em class=rfc2119>must</em> initiate formation of the [=W3C Council=],
+	which should be <a href="#council-convention">convened</a> within 45 days of being initiated.
+	Concurrently, it must prepare a report for the [=Council=]
+	documenting its findings and attempts to find consensus.
 
 <h4 id=council>
 The W3C Council</h4>
@@ -2411,12 +2416,14 @@ Council Chairing</h5>
 	falling back to a vote if that fails.
 	The chair must be a member of that [=W3C Council=].
 
-	<p id=council-convention>
-	Upon appointment of the [=W3C Council Chair=],
-	the [=W3C Council=] is considered to be convened.
-
 <h5 id=council-deliberations>
 Council Deliberations</h5>
+
+	<p id=council-convention>
+	Upon appointment of the [=W3C Council Chair=]
+	and delivery of the [=Team=]’s report,
+	the [=W3C Council=] is considered to be convened
+	and can start deliberations.
 
 	Having reviewed the information gathered by the [=Team=],
 	the Council <em class=rfc2119>may</em> conduct additional research or analysis,

--- a/index.bs
+++ b/index.bs
@@ -5281,15 +5281,10 @@ Rejection of a Submission Request, and Submission Appeals</h3>
 	the Team <em class="rfc2119">must not</em> make statements about why a Submission request was rejected.
 
 	The [=Advisory Committee representative=](s) of the [=Submitters=](s)
-	<em class="rfc2119">may</em> initiate a Submission Appeal
-	of the [=Team's Decision=] to the [=TAG=]
-	if the reasons are related to Web architecture,
-	or to the [=Advisory Board=]
-	if the request is rejected for other reasons.
-	In this case the [=Team=] <em class="rfc2119">should</em> make available
-	its rationale for the rejection to the appropriate body.
-	The [=Team=] will establish a process for such appeals
-	that ensures the appropriate <a href="#confidentiality-levels">level of confidentiality</a>.
+	<em class="rfc2119">may</em> initiate a [=Submission Appeal=].
+	The procedure for handling <dfn>Submission Appeals</dfn> is the same as for [=Formal Objections=],
+	except that an [=AC Appeal=] is not possible
+	and both the Formal Objection and the [=Council Report=] are confidential to the [=Team=], [=TAG=], and [=AB=].
 
 <h2 id="GAProcess">
 Process Evolution</h2>

--- a/index.bs
+++ b/index.bs
@@ -2291,7 +2291,7 @@ Investigation and Mediation by the Team</h4>
 	the individual withdraws the objection and the disposition process terminates.
 
 	Otherwise,
-	within at most 45 days of a [=Formal Objection=] being registered,
+	within at most 90 days of a [=Formal Objection=] being registered,
 	the [=Team=] <em class=rfc2119>must</em> initiate formation of the [=W3C Council=]
 	and prepare a report of its findings
 	and attempts to find consensus.
@@ -2448,7 +2448,7 @@ Council Deliberations</h5>
 
 	The deliberations of the [=W3C Council=] are confidential to the [=W3C Council=].
 
-	If the [=W3C Council=] is unable to come to a conclusion within 90 days of being <a href="#council-convention">convened</a>,
+	If the [=W3C Council=] is unable to come to a conclusion within 45 days of being <a href="#council-convention">convened</a>,
 	the [=W3C Council Chair=] <em class=rfc2119>must</em> inform the [=AC=] of this delay
 	and of the status of the discussions.
 	The [=W3C Council Chair=] <em class=rfc2119>may</em> additionally make this report <a href="#confidentiality-levels">public</a>.

--- a/index.bs
+++ b/index.bs
@@ -2291,12 +2291,16 @@ Investigation and Mediation by the Team</h4>
 	the individual withdraws the objection and the disposition process terminates.
 
 	Otherwise,
-	within at most 45 days of the [=Formal Objection=] being registered,
-	the [=Team=] must present its conclusions (or lack thereof)
-	to the [=W3C Council=].
+	within at most 45 days of a [=Formal Objection=] being registered,
+	the [=Team=] <em class=rfc2119>must</em> initiate formation of the [=W3C Council=]
+	and prepare a report of its findings
+	and attempts to find consensus.
 
 <h4 id=council>
 The W3C Council</h4>
+
+<h5 id=council-composition>
+Council Composition</h5>
 
 	The <dfn local-lt="Council">W3C Council</dfn> consists of the following members,
 	with the exception of any who are [=dismissed=] or who formally [=renounce=] their position:
@@ -2311,10 +2315,28 @@ The W3C Council</h4>
 	and is not changed by any [=AB=] or [=TAG=] elections
 	occurring before that Council has reached a conclusion.
 	However, if participation in a [=Council=] falls so low as to hinder effective and balanced deliberations,
-	the [=Chair of the Council=] <em class="rfc2119">should</em> dissolve the [=Council=]
+	the [=W3C Council Chair=] <em class="rfc2119">should</em> dissolve the [=Council=]
 	and call for a new one to be convened.
 
 	A [=Team=] member is assigned to support the Council.
+
+<h5 id=council-delegation>
+Extraordinary Delegation</h5>
+
+	In extraordinary cases,
+	if they feel the [=Council=] would not be the appropriate deciding body,
+	a member of the [=Team=] (particularly the Legal Counsel) or
+	any potential Council member
+	may suggest that the decision for that specific Formal Objection be delegated
+	to the W3C Board of Directors,
+	to an officer of its corporation (such as the Legal Counsel),
+	or to one or more specific individuals from the [=Team=].
+	The potential Council members then <em class=rfc2119>may</em> confidentially discuss
+	and <em class=rfc2119>must</em> vote
+	whether to delegate the decision for that specific [=Formal Objection=].
+	A decision to delegate <em class=rfc2119>must</em> be supported by a two-thirds supermajority vote
+	(i.e., at least twice as many votes in favor as against).
+	Delegation in such cases cannot be later revoked.
 
 <h5 id=council-participation>
 Council Participation, Dismissal, and Renunciation</h5>
@@ -2376,67 +2398,84 @@ Council Participation, Dismissal, and Renunciation</h5>
 	The [=W3C Council=] <em class=rfc2110>may</em> still solicit and hear their testimony,
 	as they can of anyone else in the W3C community.
 
-	The <dfn local-lt="Chair of the Council">Chair of the W3C Council</dfn> for a particular topic is chosen by its members,
+<h5 id=council-chairing>
+Council Chairing</h5>
+
+	The <dfn lt="W3C Council Chair">Chair</dfn> of each W3C Council is chosen by its members,
 	by consensus if possible,
 	falling back to a vote if that fails.
-	The chair must be a member of the [=W3C Council=].
+	The chair must be a member of that [=W3C Council=].
 
-	In extraordinary cases,
-	if the [=Council=] determines that it would not be the appropriate body to handle a particular [=Formal Objection=],
-	it <em class=rfc2119>may</em> decide by a ⅔ supermajority vote
-	(i.e. twice as many votes in favor as against)
-	to delegate the decision for that specific [=Formal Objection=]
-	to the W3C Board of Directors,
-	to an officer of its corporation (such as the Legal Counsel),
-	or to one or more specific individuals from the [=Team=].
-	Delegation in such cases cannot be later revoked.
+	<p id=council-convention>
+	Upon appointment of the [=W3C Council Chair=],
+	the [=W3C Council=] is considered to be convened.
 
-	Otherwise, having reviewed the information gathered by the [=Team=] and its recommendation,
+<h5 id=council-deliberations>
+Council Deliberations</h5>
+
+	Having reviewed the information gathered by the [=Team=],
 	and after sufficient sufficient deliberation,
 	the [=W3C Council=] decides whether to
 	<dfn>sustain</dfn> or <dfn>overrule</dfn> the objection.
 	When [=sustaining=] an objection,
 	it <em class=rfc2199>should</em> recommend a way forward.
 
-	The Council <em class=rfc2119>may</em> form subsets for deliberation and to return with a recommendation,
+	Individuals registering [=Formal Objections=] often support their reasoning
+	with several arguments.
+	The [=W3C Council=] <em class=rfc2119>may</em> [=overrule=] the [=Formal Objection=]
+	even if it agrees with some of the supportive arguments.
+
+	The Council <em class=rfc2119>may</em> form sub-groups for deliberation,
+	who may return with a recommendation,
 	but the full Council issues the final decision.
-	Decision of the [=W3C Council=] should be unanimous.
-	If despite careful deliberation
+	The decision of the [=W3C Council=] <em class=rfc2119>should</em> be unanimous,
+	and <em class=rfc2119>may</em> be issued under consensus.
+	However, if despite careful deliberation
 	the [=W3C Council=] is unable to reach consensus,
-	the [=Chair of the W3C Council=] may instead resort to voting.
+	the [=W3C Council Chair=] may instead resort to voting.
 	In that case,
 	the decision is made by simple majority,
-	with the [=Chair of the W3C Council=] breaking ties.
-
-	If the [=Council=] needs to resort to a vote,
-	and if two members of the council who share the same affiliation cast an identical ballot,
+	with the [=W3C Council Chair=] breaking any tie.
+	In case of a vote,
+	if two members of the Council who share the same affiliation cast an identical ballot,
 	then their ballots count as a one vote,
 	not two.
 
-	If the [=W3C Council=] is unable to come to a conclusion within 90 days of being initially convened for a particular topic,
-	the [=Chair of the W3C Council=] <em class=rfc2119>must</em> inform the [=AC=] of this delay
-	and of the status of the discussions.
-	The [=Chair of the W3C Council=] <em class=rfc2119>may</em> additionally make this report <a href="#confidentiality-levels">public</a>.
-
-	The deliberations of the [=W3C Council=] are confidential to the [=W3C Council=].
-	Decisions of the [=W3C Council=] <em class=rfc2119>must</em> have the same level of confidenntiality
-	as the object of the [=Formal Objection=].
-	A rationale supporting the decision <em class=2119>must</em> be provided as well.
 	In the case of non-unanimous decisions,
 	members of the [=W3C Council=] who disagree with the decision
 	<em class=rfc2119>may</em> write a <dfn>Minority Opinion</dfn>
 	explaining the reason for their disagreement.
-	[=Minority Opinions=] <em class=rfc2119>must</em> be included in the announcement of the decision.
 
-	Individuals registering [=Formal Objections=] often support their reasoning
-	with several arguments.
-	In the rationale explaining its decision,
-	the [=W3C Council=] must address each point.
-	The [=W3C Council=] <em class=rfc2119>may</em> [=overrule=] the [=Formal Objection=]
-	even if it agrees with some of the supportive arguments.
+	The deliberations of the [=W3C Council=] are confidential to the [=W3C Council=].
 
-	[=Advisory Committee representatives=] may initiate an [=Advisory Committee Appeal=]
-	of the [=W3C Council=]'s decision.
+	If the [=W3C Council=] is unable to come to a conclusion within 90 days of being <a href="#council-convention">convened</a>,
+	the [=W3C Council Chair=] <em class=rfc2119>must</em> inform the [=AC=] of this delay
+	and of the status of the discussions.
+	The [=W3C Council Chair=] <em class=rfc2119>may</em> additionally make this report <a href="#confidentiality-levels">public</a>.
+
+<h5 id=council-decision>
+Council Decision Report</h5>
+
+	The [=Council=] terminates by issuing a <dfn>Council Report</dfn>,
+	which:
+	* <em class=rfc2119>must</em> state whether the Council [=sustains=] or [=overrules=] the objection.
+	* <em class=rfc2119>must</em> provide a rationale supporting the decision,
+		which <em class=rfc2119>should</em> address each argument raised in the Formal Objection(s).
+	* <em class=rfc2119>must</em> include any recommendation decided by the [=Council=].
+	* <em class=rfc2119>must</em> include the [=Minority Opinion=](s), if any.
+	* <em class=rfc2119>must</em> report the names of those who were [=dismissed=] or [=renounced=] their seat as well as those who were qualified to serve.
+	* <em class=rfc2119>must</em> report the names of the individuals who participated in the final decision.
+	* <em class=rfc2119>must not</em> report individual votes or vote totals, if any vote was held.
+	* <em class=rfc2119>must not</em> attribute any point to any individual on the Council.
+
+	Decisions of the [=W3C Council=] <em class=rfc2119>must</em> have the same level of confidentiality
+	as the object of the [=Formal Objection=].
+
+<h5 id=council-appeals>
+Appealing Council Decisions</h5>
+
+	[=Advisory Committee representatives=] <em class=rfc2119>may</em> initiate an [=Advisory Committee Appeal=]
+	of a Council decision issued in a [=Council Report=].
 
 <h3 id="ACReview">
 Advisory Committee Reviews</h3>


### PR DESCRIPTION
This pull requests integrates all the changes prepared over the years for the director-free branches related to handling of formal objections by the W3C Council, and related matters.

The commits presented here do not attempt to reflect the full history of changes: these would be too many to comfortably review, often adding changes and the reverting or changing them further. Instead, these commits try to split the matter in largely thematic edits.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/pull/642.html" title="Last updated on Oct 13, 2022, 3:39 PM UTC (b9a0119)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/642/c83bf6b...b9a0119.html" title="Last updated on Oct 13, 2022, 3:39 PM UTC (b9a0119)">Diff</a>