### PR TITLE
Refactor Group/Chair Decision Appeal and Formal Objection sections

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2213,56 +2213,45 @@ Reopening a Decision When Presented With New Information</h3>
 	that a decision has been reopened,
 	and <em class="rfc2119">must</em> do so upon request from a group participant.
 
-<h3 id="WGAppeals">
-[=Chair Decision=] and [=Group Decision=] Appeals</h3>
-
-	When group participants believe that their concerns are not being duly considered by the group or the [=Chair=],
-	they <em class="rfc2119">may</em> ask that the decision be confirmed or denied
-	(for representatives of a Member organization, via their Advisory Committee representative).
-	This is a <dfn export id="wg-decision-appeal">Group Decision Appeal</dfn>
-	or a <dfn export id="chair-decision-appeal">Chair Decision Appeal</dfn>.
-	The participants <em class="rfc2119">should</em> also make their requests known
-	to the <a href="#TeamContact">Team Contact</a>.
-	The Team Contact <em class="rfc2119">must</em> inform the [=CEO=]
-	when a group participant has also raised concerns about due process.
-
-	Any requests to confirm a decision
-	<em class="rfc2119">must</em> include a summary of
-	the issue (whether technical or procedural),
-	decision,
-	and rationale for the objection.
-	All counter-arguments,
-	rationales,
-	and decisions <em class="rfc2119">must</em> be recorded.
-
-	The procedure for handling [=Group Decision Appeals=]
-	and [=Chair Decision Appeals=]
-	is the same as for [=Formal Objections=].
-
-	Procedures for <a href="#ACAppeal">Advisory Committee appeals</a> are described separately.
-
-<h3 id="WGArchiveMinorityViews">
+<h3 id="registering-objections" oldids="WGArchiveMinorityViews, WGAppeals, wg-decision-appeal, chair-decision-appeal">
 Registering Formal Objections</h3>
 
 	In the W3C process,
-	an individual <em class="rfc2119">may</em> register a Formal Objection to a decision.
-	A <dfn id="FormalObjection">Formal Objection</dfn> to a group decision
-	is one that the reviewer requests that the W3C consider
-	as part of evaluating the related decision
-	(e.g., in response to a <a href="#rec-advance">request to advance</a> a technical report).
+	any individual <em class="rfc2119">may</em> appeal a decision
+	by registering a <dfn id="FormalObjection">Formal Objection</dfn> with the [=Team=]
+	when they believe that their concerns are not being duly considered.
+	Group participants <em class="rfc2119">should</em> inform
+	their <a href="#TeamContact">Team Contact</a> as well as the group's Chair(s).
+	The Team Contact <em class="rfc2119">must</em> inform the [=CEO=]
+	when a group participant has also raised concerns about due process.
 
 	Note: In this document, the term [=Formal Objection=] is used to emphasize this process implication:
 	Formal Objections receive formal consideration and a formal response.
-	The word “objection” used alone has ordinary English connotations.
+	The word “objection” used alone has its ordinary English connotations.
 
-	An individual who registers a [=Formal Objection=] <em class="rfc2119">should</em> cite technical arguments
+	A [=Formal Objection=]
+	<em class="rfc2119">must</em> include a summary of
+	the issue (whether technical or procedural),
+	the decision being appealed,
+	and the rationale for the objection.
+	It <em class="rfc2119">should</em> cite technical arguments
 	and propose changes that would remove the [=Formal Objection=];
 	these proposals <em class="rfc2119">may</em> be vague or incomplete.
 	[=Formal Objections=] that do not provide substantive arguments
 	or rationale are unlikely to receive serious consideration.
+	Counter-arguments,
+	rationales,
+	and decisions <em class="rfc2119">should</em> also be recorded.
 
-	A record of each [=Formal Objection=] <em class="rfc2119">must</em> be <a href="#confidentiality-change">publicly available</a>.
-	A Call for Review (of a document) to the Advisory Committee <em class="rfc2119">must</em> identify any [=Formal Objections=].
+	A record of each [=Formal Objection=] regarding a publicly-available document
+	<em class="rfc2119">must</em> be made <a href="#confidentiality-change">publicly available</a>.
+	A Call for Review to the Advisory Committee
+	<em class="rfc2119">must</em> identify any [=Formal Objections=]
+	related to that review.
+
+	Note: [=Formal Objections=] against matter in a [=technical report=]
+	are required to be addressed before <a href="#rec-advance">requesting advancement</a>
+	of the [=technical report=].
 
 <h3 id=addressing-fo>
 Addressing Formal Objections</h3>


### PR DESCRIPTION
Based on the changes introduced by the director free project and introduction of the Council,  Group/Chair Decision Appeal and Formal Objection are no longer meaningfully different. Merging them makes the Process shorter, easier to understand, and reduces the amount of specialized terminology we need to introduce.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/643.html" title="Last updated on Sep 30, 2022, 9:29 AM UTC (c3f8cf9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/643/d0885a5...frivoal:c3f8cf9.html" title="Last updated on Sep 30, 2022, 9:29 AM UTC (c3f8cf9)">Diff</a>