### PR TITLE
Define editorial vs substantive changes for non-REC-track documents.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2627,7 +2627,7 @@ Wide Review</h5>
 Classes of Changes</h4>
 
 
-	This document distinguishes the following 5 classes of changes to a specification.
+	This document distinguishes the following 5 classes of changes to a document.
 	The first two classes of change are considered <dfn lt="editorial change">editorial changes</dfn>,
 	the next two <dfn lt="substantive change">substantive changes</dfn>,
 	and the last one <dfn lt="registry change">registry changes</dfn>.
@@ -2636,12 +2636,14 @@ Classes of Changes</h4>
 		<dt id=class-1>
 			1. No changes to text content
 		<dd>
-			These changes include fixing broken links, style sheets or invalid markup.
+			These changes include fixing broken links, style sheets, or invalid markup.
 
 		<dt id=class-2>
-			2. Corrections that do not affect conformance
+			2. Changes that do not functionally affect interpretation of the document
 		<dd>
-			Changes that reasonable implementers
+			For [=Recommendation-track=] [=technical reports=] specifically,
+            this constitutes changes that do not affect conformance,
+            i.e. changes that reasonable implementers
 			would not interpret as changing architectural
 			or interoperability requirements
 			or their implementation.
@@ -2650,19 +2652,21 @@ Classes of Changes</h4>
 			and do not fall into this class.
 		<dd>
 			Examples of changes in this class include
-			correcting non-normative code examples
-			where the code clearly conflicts with normative requirements,
+			correcting non-normative examples
+			which clearly conflict with normative requirements,
 			clarifying informative use cases or other non-normative text,
 			fixing typos or grammatical errors
-			where the change does not change implementation requirements.
+			where the change does not change requirements.
+		<dd>
 			If there is any doubt or disagreement
-			as to whether requirements are changed,
-			such changes do not fall into this class.
+			as to whether a change functionally affects interpretation,
+			that change does not fall into this class.
 
 		<dt id=class-3>
-			3. Corrections that do not add new features
+			3. Other changes that do not add new features
 		<dd>
-			These changes <em class="rfc2119">may</em> affect conformance to the specification.
+			For [=Recommendation-track=] documents,
+            these changes <em class="rfc2119">may</em> affect conformance to the specification.
 			A change that affects conformance is one that:
 
 			<ul>
@@ -2684,7 +2688,8 @@ Classes of Changes</h4>
 		<dt id=class-4>
 			4. New features
 		<dd>
-			Changes that add a new functionality, element, etc.
+			Changes that add new functionality,
+			such as new elements, new APIs, new rules, etc.
 
 		<dt id=class-5>
 			5. Changes to the contents of a [=registry table=]


### PR DESCRIPTION
Prior to this change, the 4 classes of changes were well-defined for REC-track documents, but not anything else. However, we need to distinguish editorial vs substantive changes for any document that passes through AC review, e.g. charters, Statements, the Process itself, CEPC, etc. 

Related to #28


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fantasai/w3process/pull/647.html" title="Last updated on Sep 30, 2022, 9:35 AM UTC (d106b76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/647/d57f69a...fantasai:d106b76.html" title="Last updated on Sep 30, 2022, 9:35 AM UTC (d106b76)">Diff</a>