### PR TITLE
Include Council Team Contact in the confidence of the Council

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2494,7 +2494,8 @@ Council Deliberations</h5>
 	<em class=rfc2119>may</em> write a <dfn>Minority Opinion</dfn>
 	explaining the reason for their disagreement.
 
-	The deliberations of the [=W3C Council=] are confidential to the [=W3C Council=].
+	The deliberations of the [=W3C Council=] are confidential to the [=W3C Council=]
+	and its [=Council Team Contact=].
 
 	If the [=W3C Council=] is unable to come to a conclusion within 45 days of being <a href="#council-convention">convened</a>,
 	the [=W3C Council Chair=] <em class=rfc2119>must</em> inform the [=AC=] of this delay


### PR DESCRIPTION
If the Council Team Contact is to help the Council stick to the Process, it needs to see what it's doing (or not doing).

Given that the membership and chairing of the Council frequently changes, it is difficult for the Council to always be on top of how they're supposed to be run, and the Council Team Contact, if in the room, can help with that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/702.html" title="Last updated on Jan 25, 2023, 3:29 AM UTC (dc75481)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/702/c2ab25d...frivoal:dc75481.html" title="Last updated on Jan 25, 2023, 3:29 AM UTC (dc75481)">Diff</a>