### PR TITLE
Correct reference to W3C Document / Software licensing

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4854,9 +4854,8 @@ Public Communication</h3>
 	<ul>
 		<li>
 			<a href="#Reports">W3C technical reports</a> whose publication has been approved.
-			Per the Membership Agreement,
-			W3C technical reports (and software) are available free of charge to the general public;
-			(refer to the <a href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document License</a> [[DOC-LICENSE]]).
+			Per [[W3C-IPR inline]],
+			W3C technical reports (and software) are available free of charge to the general public.
 
 		<li>
 			A <a href="https://www.w3.org/Consortium/mission">mission statement</a> [[MISSION]]
@@ -5938,6 +5937,11 @@ Changes since earlier versions</h3>
 	"BYLAWS": {
 		"href": "https://www.w3.org/2022/10/w3c-bylaws-20221019.pdf",
 		"title": "Amended and Restated Bylaws of World Wide Web Consortium, Inc."
+	},
+	"W3C-IPR": {
+		"href": "https://www.w3.org/Consortium/Legal/2002/ipr-notice-20021231",
+		"title": "W3C IPR Policies"
 	}
+
 }
 </pre>


### PR DESCRIPTION
See #681


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/705.html" title="Last updated on Jan 25, 2023, 6:14 AM UTC (656469d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/705/c2ab25d...frivoal:656469d.html" title="Last updated on Jan 25, 2023, 6:14 AM UTC (656469d)">Diff</a>