### PR TITLE
Enable changes of chair in a Council

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2436,9 +2436,10 @@ Council Chairing</h5>
 	by consensus if possible,
 	falling back to a vote if that fails.
 	The chair must be a member of that [=W3C Council=].
-	Chair selection happens at least at formation of each Council.
-	The [=Council Team Contact=] <em class=rfc2119>may</em> ask the Council to re-run chair selection
-	during the Council's life-time.
+	Chair selection happens during formation of each Council,
+	and <em class=rfc2119>must</em> be re-run
+	if requested by the [=Council Team Contact=]
+	during the Council’s operation.
 
 <h5 id=council-deliberations>
 Council Deliberations</h5>

--- a/index.bs
+++ b/index.bs
@@ -2438,7 +2438,7 @@ Council Chairing</h5>
 	The chair must be a member of that [=W3C Council=].
 	Chair selection happens during formation of each Council,
 	and <em class=rfc2119>must</em> be re-run
-	if requested by the [=Council Team Contact=]
+	if requested by the [=Council Team Contact=] or by the [=Chair=]
 	during the Council’s operation.
 
 <h5 id=council-deliberations>

--- a/index.bs
+++ b/index.bs
@@ -2436,6 +2436,9 @@ Council Chairing</h5>
 	by consensus if possible,
 	falling back to a vote if that fails.
 	The chair must be a member of that [=W3C Council=].
+	Chair selection happens at least at formation of each Council.
+	The [=Council Team Contact=] <em class=rfc2119>may</em> ask the Council to re-run chair selection
+	during the Council's life-time.
 
 <h5 id=council-deliberations>
 Council Deliberations</h5>


### PR DESCRIPTION
As per [AB resolution](https://lists.w3.org/Archives/Member/w3c-ac-forum/2023JanMar/0082.html):
> the Team Contact can request the Council re-run the chair selection (if the chair needs to step down, for example).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/709.html" title="Last updated on Feb 8, 2023, 4:48 PM UTC (51e5b97)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/709/6b93af8...frivoal:51e5b97.html" title="Last updated on Feb 8, 2023, 4:48 PM UTC (51e5b97)">Diff</a>