### PR TITLE
Fix up inconsistencies in the confidentiality of FOs and Council Reports

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2283,8 +2283,10 @@ Registering Formal Objections</h3>
 	rationales,
 	and decisions <em class="rfc2119">should</em> also be recorded.
 
-	A record of each [=Formal Objection=] regarding a publicly-available document
-	<em class="rfc2119">must</em> be made <a href="#confidentiality-change">publicly available</a>.
+	A record of each [=Formal Objection=] against a decision regarding a publicly-available document
+	<em class="rfc2119">must</em> be made <a href="#confidentiality-change">publicly available</a>;
+	likewise, a record of each [=Formal Objection=] against a [=Member-only|Member-visible=] decision
+	<em class="rfc2119">must</em> be made <a href="#confidentiality-change">available to Members</a>.
 	A Call for Review to the Advisory Committee
 	<em class="rfc2119">must</em> identify any [=Formal Objections=]
 	related to that review.
@@ -2534,9 +2536,9 @@ Council Deliberations</h5>
 <h5 id=council-decision>
 Council Decision Report</h5>
 
-	A [=Council=] terminates by issuing a <dfn>Council Report</dfn>,
+	A [=Council=] terminates by issuing a <dfn export>Council Report</dfn>,
 	which:
-	* <em class=rfc2119>must</em> state whether the Council [=sustains=] or [=overrules=] the objection.
+	* <em class=rfc2119>must</em> state whether the Council [=sustains=] or [=overrules=] the objection(s).
 	* <em class=rfc2119>must</em> provide a rationale supporting the decision,
 		which <em class=rfc2119>should</em> address each argument raised in the Formal Objection(s).
 	* <em class=rfc2119>must</em> include any recommendation decided by the [=Council=].
@@ -2551,8 +2553,15 @@ Council Decision Report</h5>
 	indexing all completed [=Council Reports=].
 	If a Council decision is later overturned by an [=AC Appeal=],
 	this <em class=rfc2119>must</em> also be mentioned.
-	[=Council Reports=] <em class=rfc2119>must</em> have the same level of confidentiality
-	as the [=Formal Objection=].
+	[=Council Reports=] <em class=rfc2119>must</em> be no more confidential
+	than the decision or document being objected to.
+
+	The [=Council=] <em class=rfc2119>may</em> also issue a <dfn export>Supplemental Confidential Council Report</dfn>
+	with a more restricted <a href="#confidentiality-levels">level of confidentiality</a> than its main report
+	when it believes that additional commentary on confidential aspects of the case
+	would be informative.
+	However, the main [=Council Report=] <em class=rfc2119>should</em> be self-sufficient
+	and understandable without reference to Supplemental Confidential Council Reports.
 
 <h5 id=council-appeals>
 Appealing Council Decisions</h5>


### PR DESCRIPTION
See #717


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 22, 2023, 3:15 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffrivoal%2Fw3process%2Ff974dd418260f6a3e5f171b86c8d106ca99f24c5%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: LINE 26: The document's metadata block should be the first thing in the document. Please move this block to the top.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/w3process%23720.)._
</details>
