### PR TITLE
Fix typo in description of Council formation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2343,7 +2343,7 @@ Council Composition</h5>
 	Participation in a [=W3C Council=] <em class=rfc2119>must not</em> require attendance of [=face-to-face meetings=].
 
 	A distinct instance of the [=W3C Council=] is convened for each decision being appealed or objected to.
-	Membership of an instance the [=Council=] is be fixed at formation,
+	Membership of an instance the [=Council=] is fixed at formation,
 	and is not changed by any [=AB=] or [=TAG=] elections
 	occurring before that Council has reached a conclusion.
 	However, if participation in a [=Council=] falls so low as to hinder effective and balanced deliberations,

--- a/index.bs
+++ b/index.bs
@@ -2343,7 +2343,7 @@ Council Composition</h5>
 	Participation in a [=W3C Council=] <em class=rfc2119>must not</em> require attendance of [=face-to-face meetings=].
 
 	A distinct instance of the [=W3C Council=] is convened for each decision being appealed or objected to.
-	Membership of an instance the [=Council=] is fixed at formation,
+	Membership of each [=Council=] instance is fixed at formation,
 	and is not changed by any [=AB=] or [=TAG=] elections
 	occurring before that Council has reached a conclusion.
 	However, if participation in a [=Council=] falls so low as to hinder effective and balanced deliberations,


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chrisn/w3process/pull/759.html" title="Last updated on May 19, 2023, 2:20 AM UTC (ae75b55)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/759/189b5ec...chrisn:ae75b55.html" title="Last updated on May 19, 2023, 2:20 AM UTC (ae75b55)">Diff</a>