### PR TITLE
Exclude TAG/AB from voting on their own decisions/proposals. #749

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2520,7 +2520,7 @@ Council Deliberations</h5>
 	However,
 	if the decision or proposal being objected to
 	originated with the TAG or AB,
-	then members of that group [at the time the decision or proposal was made]
+	then members of that group at the time the decision or proposal was made
 	must abstain in such a vote.
 	In case of a vote,
 	if two members of a Council who share the same affiliation cast an identical ballot,

--- a/index.bs
+++ b/index.bs
@@ -2517,6 +2517,11 @@ Council Deliberations</h5>
 	In that case,
 	the decision is made by simple majority,
 	with the [=W3C Council Chair=] breaking any tie.
+	However,
+	if the decision or proposal being objected to
+	originated with the TAG or AB,
+	then members of that group [at the time the decision or proposal was made]
+	must abstain in such a vote.
 	In case of a vote,
 	if two members of a Council who share the same affiliation cast an identical ballot,
 	then their ballots count as a one vote,


### PR DESCRIPTION
There are two variants possible: see bracketed text, which could be kept or removed.

(Personally, I prefer removing it, for simplicity; but could live with either way.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fantasai/w3process/pull/761.html" title="Last updated on Oct 11, 2023, 2:55 PM UTC (a000179)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/761/321e97e...fantasai:a000179.html" title="Last updated on Oct 11, 2023, 2:55 PM UTC (a000179)">Diff</a>