### PR TITLE
Disambiguate sustain

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2488,12 +2488,12 @@ Council Deliberations</h5>
 	Otherwise,
 	after sufficient deliberation,
 	the [=W3C Council=] decides whether to
-	<dfn>sustain</dfn> or <dfn>overrule</dfn> the objection.
+	<dfn lt="uphold | upholds | upheld | upholding">uphold</dfn> or <dfn>overrule</dfn> the objection.
 	The [=W3C Council=] <em class=rfc2119>may</em> [=overrule=] the [=Formal Objection=]
 	even if it agrees with some of the supportive arguments.
 
 	<p id=fo-mitigations>
-	When [=sustaining=] an objection,
+	When [=upholding=] an objection,
 	it <em class=rfc2199>should</em> recommend a way forward.
 	If the overturned decision has already had consequences
 	(e.g., if the objection concerns material already in a published document)
@@ -2540,11 +2540,11 @@ Council Decision Report</h5>
 
 	A [=Council=] terminates by issuing a <dfn export>Council Report</dfn>,
 	which:
-	* <em class=rfc2119>must</em> state whether the Council [=sustains=] or [=overrules=] the objection(s).
+	* <em class=rfc2119>must</em> state whether the Council [=upholds=] or [=overrules=] the objection(s).
 	* <em class=rfc2119>must</em> provide a rationale supporting the decision,
 		which <em class=rfc2119>should</em> address each argument raised in the Formal Objection(s).
 	* <em class=rfc2119>must</em> include any recommendation decided by the [=Council=].
-	* if the [=Formal Objection=] has been sustained, <em class=rfc2119>should</em> include any suggested <a href="#fo-mitigations">mitigations</a>.
+	* if the [=Formal Objection=] has been upheld, <em class=rfc2119>should</em> include any suggested <a href="#fo-mitigations">mitigations</a>.
 	* <em class=rfc2119>must</em> include the [=Minority Opinion=](s), if any.
 	* <em class=rfc2119>must</em> report the names of those who were [=dismissed=] or [=renounced=] their seat as well as those who were qualified to serve.
 	* <em class=rfc2119>must</em> report the names of the individuals who participated in the final decision.
@@ -2633,7 +2633,7 @@ After the Review Period</h4>
 	with attention to <a href="#confidentiality-change">changing the confidentiality level</a> of the [=Formal Objections=].
 
 	If there is [=dissent=]
-	(i.e., there were [=Formal Objections=], at least some of which were sustained)
+	(i.e., there were [=Formal Objections=], at least some of which were upheld)
 	or if there is not [=consensus=] because of insufficient support,
 	[=W3C Decision=] <em class=rfc2119>must</em> be one of:
 
@@ -3480,7 +3480,7 @@ Advancement on the Recommendation Track</h4>
 			[=Team=] verification (a [=Team decision=])
 			<em class=rfc2119>must</em> be withheld if any Process requirements are not met
 			or if there remain any unresolved Formal Objections
-			(including any [=sustained=] by a [=Council=] but not yet [=fully addressed=]),
+			(including any [=upheld=] by a [=Council=] but not yet [=fully addressed=]),
 			or if the document does not adequately reflect all relevant decisions of the [=W3C Council=] (or its delegates).
 			If the [=Team=] rejects a [=Transition Request=]
 			it <em class=rfc2119>must</em> indicate its rationale
@@ -3553,7 +3553,7 @@ Updating Mature Publications on the Recommendation Track</h4>
 			[=Team=] verification (a [=Team decision=]),
 			<em>should</em> be withheld if any Process requirements are not met,
 			and <em class=rfc2119>may</em> be withheld in consideration of unresolved Formal Objections
-			(including any [=sustained=] by a [=Council=] but not yet [=fully addressed=])
+			(including any [=upheld=] by a [=Council=] but not yet [=fully addressed=])
 			or if the document does not adequately reflect all relevant decisions of the [=W3C Council=] (or its delegates).
 			If the [=Team=] rejects an [=Update Request=],
 			it must indicate its rationale to the [=Working Group=].


### PR DESCRIPTION
Use "uphold" to describe what the Council does when it agrees with an FO, to distinguish with "sustain" as used in the definition of dissent.

See #746


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/762.html" title="Last updated on May 19, 2023, 3:21 AM UTC (54f29c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/762/c87099a...frivoal:54f29c3.html" title="Last updated on May 19, 2023, 3:21 AM UTC (54f29c3)">Diff</a>