### PR TITLE
Clarify 'formal contexts' for Formal Objections

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2061,7 +2061,7 @@ Consensus</h4>
 
 	Note: A [=Formal Objection=] always indicates a sustained objection,
 	but isn't necessary to express it
-	(except in some formal contexts such as [=AC Reviews=]).
+	(except in the context of formal [=AC Reviews=]).
 	Disagreement with a proposed decision,
 	however, does not always rise to the level of sustained objection,
 	as individuals could be willing to accept a decision


### PR DESCRIPTION
See #746. As AC review is currently the only context where sustained objection must be expressed as an FO, this PR changes the Note to say that. The hope is that we avoid introducing other contexts in future.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chrisn/w3process/pull/763.html" title="Last updated on May 19, 2023, 11:14 AM UTC (eb963d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/763/c87099a...chrisn:eb963d3.html" title="Last updated on May 19, 2023, 11:14 AM UTC (eb963d3)">Diff</a>