### PR TITLE
informative role of chair/contact. fixes #765

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1415,14 +1415,18 @@ Requirements for All Chartered Groups</h4>
 	or an <a href="#invited-expert-wg">Invited Expert</a>,
 	(invited by the [=Team=]).
 	The requirements of this document that apply to those types of participants apply to Chairs as well.
-	The <a href="https://www.w3.org/Guide/chair/role.html">role of the Chair</a> [[CHAIR]] is described
+	
+	Note: The <a href="https://www.w3.org/Guide/chair/role.html">role of the Chair</a> [[CHAIR]] is described
 	in the <a href="https://www.w3.org/Guide/">Art of Consensus</a> [[GUIDE]].
 
 	Each group <em class="rfc2119">must</em> have a <dfn id="TeamContact" export>Team Contact</dfn>,
 	who acts as the interface between the [=Chair=],
 	group participants,
 	and the rest of the Team.
-	The <a href="https://www.w3.org/Guide/teamcontact/role.html">role of the Team Contact</a> [[TEAM-CONTACT]] is described in the <a href="https://www.w3.org/Guide/">Art of Consensus</a> [[GUIDE]].
+	
+	Note: The <a href="https://www.w3.org/Guide/teamcontact/role.html">role of the Team Contact</a> [[TEAM-CONTACT]] 
+	is described in the <a href="https://www.w3.org/Guide/">Art of Consensus</a> [[GUIDE]].
+				
 	The [=Chair=] and the [=Team Contact=] of a group <em class="rfc2119">should not</em> be the same individual.
 
 	Each group <em class="rfc2119">must</em> have an archived mailing list


### PR DESCRIPTION
Mark role of chair / team contact sentences as informative notes to be consistent with their informative references to the Guide which is referenced as describing those roles. This PR fixes issue #765


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tantek/w3process/pull/766.html" title="Last updated on May 27, 2023, 5:48 AM UTC (de9e858)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/766/297b4cc...tantek:de9e858.html" title="Last updated on May 27, 2023, 5:48 AM UTC (de9e858)">Diff</a>