### PR TITLE
update link to W3C submissions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5218,7 +5218,7 @@ Member Submission Process</h2>
 	A Member Submission made available by W3C
 	<em class="rfc2119">must not</em> be referred to as “work in progress” of W3C.
 
-	The list of <a href="https://www.w3.org/Submission/">acknowledged Member Submissions</a> [[SUBMISSION-LIST]]
+	The list of <a href="https://www.w3.org/submissions/">acknowledged Member Submissions</a> [[SUBMISSION-LIST]]
 	is available at the W3C website.
 
 <h3 id="SubmissionRights">
@@ -5689,7 +5689,7 @@ Changes since earlier versions</h3>
 		"publisher": "W3C"
 	},
 	"SUBMISSION-LIST": {
-		"href": "https://www.w3.org/Submission/",
+		"href": "https://www.w3.org/submissions/",
 		"title": "The list of acknowledged Member Submissions",
 		"publisher": "W3C"
 	},


### PR DESCRIPTION
With the new website URLs strategy, the submissions are now located under /submissions/ instead of /Submission/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/pull/783.html" title="Last updated on Sep 5, 2023, 1:49 PM UTC (13d44ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/783/80cac31...13d44ae.html" title="Last updated on Sep 5, 2023, 1:49 PM UTC (13d44ae)">Diff</a>