### PR TITLE
Enable Team to replace defunct registry custodians when no-one else can

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4646,6 +4646,13 @@ Registry Definitions</h4>
 			The [=custodian=] may be the [=Working Group=], the [=Team=], or a delegated entity.
 			The [=custodian=] for all [=registry tables=] in a single [=registry=]
 			<em class=rfc2119>should</em> generally be the same entity.
+
+			If a [=custodian=] of a [=registry=] becomes defunct
+			(e.g. the relevant group is disbanded),
+			and the [=Working Group=] that owns the [=registry definition=] is itself also defunct,
+			the [=Team=] <em class=rfc2119>should</em> propose replacing the [=custodian=],
+			which <em class=rfc2119>must</em> be confirmed
+			by an [=AC Review=] as a [=W3C Decision=].
 	</ul>
 
 <h4 id=reg-pub>


### PR DESCRIPTION
See issue #699