### PR TITLE
Clarify definition of the REC-track

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3186,7 +3186,7 @@ The W3C Recommendation Track</h3>
 	and if there is support from its Membership,
 	W3C publishes it as a <a href="#RecsW3C">Recommendation</a>.
 
-	In summary, the <dfn lt="W3C Recommendation Track | REC Track | Recommendation Track | Recommendation-track">W3C Recommendation Track</dfn> contains:
+	In summary, the <dfn lt="W3C Recommendation Track | REC Track | Recommendation Track | Recommendation-track">W3C Recommendation Track</dfn> consists of:
 
 	<ol>
 		<li>Publication of the [=First Public Working Draft=].

--- a/index.bs
+++ b/index.bs
@@ -3196,6 +3196,9 @@ The W3C Recommendation Track</h3>
 		<li>Publication as a [=W3C Recommendation=].
 	</ol>
 
+	A <dfn lt="W3C Recommendation Track document | REC Track document | Recommendation Track document | Recommendation-track document">W3C Recommendation Track document</dfn>
+	is any document whose current status is one of the five in the numbered list above.
+
 	<div role="region" aria-label="Basic W3C Recommendation Track">
 		<pre class=include-raw>
 			path: basic-rec-track.svg

--- a/index.bs
+++ b/index.bs
@@ -3186,7 +3186,7 @@ The W3C Recommendation Track</h3>
 	and if there is support from its Membership,
 	W3C publishes it as a <a href="#RecsW3C">Recommendation</a>.
 
-	In summary, the <dfn lt="W3C Recommendation Track | REC Track | Recommendation Track | Recommendation-track">W3C Recommendation Track</dfn> consists of:
+	In summary, the <dfn lt="W3C Recommendation Track | REC Track | Recommendation Track | Recommendation-track">W3C Recommendation Track</dfn> contains:
 
 	<ol>
 		<li>Publication of the [=First Public Working Draft=].


### PR DESCRIPTION
This PR makes it clear that a document that uses the various publication types and transitions of the REC-track is indeed on the REC-track, even if it isn't planning to go all the way to the end.

Some groups for instance have a declared intention of only going as far as CR. That doesn't make the documents on the "CR track", as there's no such thing.

See https://github.com/w3c/strategy/issues/438#issuecomment-1997685426


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/831.html" title="Last updated on Mar 27, 2024, 3:03 PM UTC (e8035da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/831/020ae90...frivoal:e8035da.html" title="Last updated on Mar 27, 2024, 3:03 PM UTC (e8035da)">Diff</a>