### PR TITLE
Eliminate potential ambiguity in dismissal

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2420,7 +2420,7 @@ Council Participation, Dismissal, and Renunciation</h5>
 	would compromise the integrity of the Council decision,
 	and vote whether to dismiss that potential member.
 	No one is allowed to vote on their own dismissal;
-	each dismissal is decided by simple majority of those not abstaining.
+	each dismissal is enacted if there are at least as many ballots for as against.
 
 	Note: Since dismissal is individual,
 	when the decision being objected to was made by the [=TAG=] or [=AB=] acting as a body,


### PR DESCRIPTION
This resolves part 3 of https://github.com/w3c/w3process/issues/838, and is based on the discussion minuted in https://github.com/w3c/w3process/issues/838#issuecomment-2022972989


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/841.html" title="Last updated on Apr 1, 2024, 1:46 AM UTC (0c0962d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/841/76ab28c...frivoal:0c0962d.html" title="Last updated on Apr 1, 2024, 1:46 AM UTC (0c0962d)">Diff</a>