### PR TITLE
[Editorial] Give context for candidate amendments when revising a REC

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4058,7 +4058,7 @@ Revising a Recommendation: Substantive Changes</h5>
 	once it has satisfied all the same criteria
 	as the rest of the [=Recommendation=],
 	including review by the community to ensure
-	the technical and editorial soundness.
+	its technical and editorial soundness.
 	To validate this, the [=Working Group=] must request
 	a [=Last Call for Review of Proposed Amendments=],
 	followed by an [=update request=].

--- a/index.bs
+++ b/index.bs
@@ -4088,7 +4088,7 @@ Revising a Recommendation: New Features</h5>
 
 	Note: [=Candidate additions=] do not normatively modify the document;
 	they editorially indicate how one might do so.
-	They are therefore be published following the provisions of [[#revised-rec-editorial]].
+	They are therefore published following the provisions of [[#revised-rec-editorial]].
 
 	A [=candidate addition=] can be made normative
 	and be folded into the main text of the [=Recommendation=]

--- a/index.bs
+++ b/index.bs
@@ -4045,12 +4045,20 @@ Revising a Recommendation: Editorial Changes</h5>
 <h5 id="revised-rec-substantive">
 Revising a Recommendation: Substantive Changes</h5>
 
+	Tentative corrections (see <a href="#class-3">class 3 changes</a>)
+	<em class=rfc2119>may</em> be annotated into a [=Recommendation=]
+	using [=candidate corrections=].
+
+	Note: [=Candidate corrections=] do not normatively modify the document;
+	they editorially indicate how one might do so.
+	They are therefore be published following the provisions of [[#revised-rec-editorial]].
+
 	A [=candidate correction=] can be made normative
 	and be folded into the main text of the [=Recommendation=],
 	once it has satisfied all the same criteria
 	as the rest of the [=Recommendation=],
 	including review by the community to ensure
-	the technical and editorial soundness of the [=candidate amendments=].
+	the technical and editorial soundness.
 	To validate this, the [=Working Group=] must request
 	a [=Last Call for Review of Proposed Amendments=],
 	followed by an [=update request=].
@@ -4073,13 +4081,18 @@ Revising a Recommendation: Substantive Changes</h5>
 <h5 id="revised-rec-features">
 Revising a Recommendation: New Features</h5>
 
-	New features (see <a href="#correction-classes">class 4 changes</a>)
-	may be incorporated into a [=Recommendation=]
+	Tentative new features (see <a href="#correction-classes">class 4 changes</a>)
+	<em class=rfc2119>may</em> be annotated into a [=Recommendation=]
 	explicitly identified as [=allow new features|allowing new features=]
 	using [=candidate additions=].
+
+	Note: [=Candidate additions=] do not normatively modify the document;
+	they editorially indicate how one might do so.
+	They are therefore be published following the provisions of [[#revised-rec-editorial]].
+
 	A [=candidate addition=] can be made normative
 	and be folded into the main text of the [=Recommendation=]
-	using the same process as for [=candidate amendments=],
+	using the same process as for [=candidate corrections=],
 	as detailed in [[#revised-rec-substantive]].
 
 	Note: This prohibition against new features unless explicitly allowed

--- a/index.bs
+++ b/index.bs
@@ -4051,7 +4051,7 @@ Revising a Recommendation: Substantive Changes</h5>
 
 	Note: [=Candidate corrections=] do not normatively modify the document;
 	they editorially indicate how one might do so.
-	They are therefore be published following the provisions of [[#revised-rec-editorial]].
+	They are therefore published following the provisions of [[#revised-rec-editorial]].
 
 	A [=candidate correction=] can be made normative
 	and be folded into the main text of the [=Recommendation=],


### PR DESCRIPTION
This change gives a little bit more context about how to make normative changes to a REC. Technically, and this is what the existing text talked about, they are made by folding in candidate amendments. However, someone just reading that section may not be aware of what candidate amendments are and how they are made to begin with.

This gives just a little bit of context to help people piece things together.

This is a (very) small step towards addressing https://github.com/w3c/w3process/issues/700


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/862.html" title="Last updated on May 2, 2024, 2:18 AM UTC (d430662)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/862/73e4446...frivoal:d430662.html" title="Last updated on May 2, 2024, 2:18 AM UTC (d430662)">Diff</a>