### PR TITLE
Consolidate similar parts of REC revision

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4039,17 +4039,7 @@ Transitioning to W3C Recommendation</h4>
 <h4 id=revising-rec oldids="rec-modify, revised-rec">
 Revising a W3C Recommendation</h4>
 
-	This section details the process for making changes to a [=Recommendation=].
-
-<h5 id="revised-rec-markup">
-Revising a Recommendation: Markup Changes</h5>
-
-	A [=Working group=] <em class="rfc2119">may</em> request republication of a [=Recommendation=]
-	to make corrections that do not result
-	in any changes to the text of the specification.
-	(See <a href="#correction-classes">class 1 changes</a>.)
-
-<h5 id="revised-rec-editorial">
+<h5 id="revised-rec-editorial" oldids="revised-rec-markup">
 Revising a Recommendation: Editorial Changes</h5>
 
 	[=Editorial changes=] to a [=Recommendation=] require no technical review of the intended changes.
@@ -4057,7 +4047,7 @@ Revising a Recommendation: Editorial Changes</h5>
 	provided there are no votes against the [=group decision|decision=] to publish,
 	<em class="rfc2119">may</em> request publication of a [=Recommendation=]
 	to make this class of change without passing through earlier maturity stages.
-	(See <a href="#correction-classes">class 2 changes</a>.)
+	(See <a href="#class-1">class 1</a> and <a href="#class-2">class 2 changes</a>.)
 
 <h5 id="revised-rec-substantive">
 Revising a Recommendation: Substantive Changes</h5>
@@ -4092,19 +4082,11 @@ Revising a Recommendation: Substantive Changes</h5>
 <h5 id="revised-rec-features">
 Revising a Recommendation: New Features</h5>
 
-	Tentative new features (see <a href="#correction-classes">class 4 changes</a>)
-	<em class=rfc2119>may</em> be annotated into a [=Recommendation=]
-	explicitly identified as [=allow new features|allowing new features=]
-	using [=candidate additions=].
-
-	Note: [=Candidate additions=] do not normatively modify the document;
-	they editorially indicate how one might do so.
-	They are therefore published following the provisions of [[#revised-rec-editorial]].
-
-	A [=candidate addition=] can be made normative
-	and be folded into the main text of the [=Recommendation=]
-	using the same process as for [=candidate corrections=],
-	as detailed in [[#revised-rec-substantive]].
+	For [=Recommendations=] explicitly identified as  [=allow new features|allowing new features=],
+	tentative new features (see <a href="#correction-classes">class 4 changes</a>)
+	<em class=rfc2119>may</em> be annotated in as [=candidate additions=],
+	and <a href="#correction-classes">class 4 changes</a> may be normatively incorporated
+	as for <a href="#correction-classes">class 3 changes</a> in [[#revised-rec-substantive]].
 
 	Note: This prohibition against new features unless explicitly allowed
 	enables third parties to depend on Recommendations having a stable feature-set,

--- a/index.bs
+++ b/index.bs
@@ -4088,9 +4088,9 @@ Revising a Recommendation: New Features</h5>
 	and <a href="#correction-classes">class 4 changes</a> may be normatively incorporated
 	as for <a href="#correction-classes">class 3 changes</a> in [[#revised-rec-substantive]].
 
-	Note: This prohibition against new features unless explicitly allowed
-	enables third parties to depend on Recommendations having a stable feature-set,
-	as they have prior to the 2020 revision of this Process.
+	Note: Limiting the addition of new features to [=Recommendations=] that explicitly allow them
+	enables third parties to depend on a stable feature-set for [=Recommendations=] that do not advertise that ability,
+	as was the case for all [=Recommendations=] prior to the 2020 revision of this Process.
 
 	To make changes which introduce a new feature
 	to a [=Recommendation=] that does not [=allow new features=],


### PR DESCRIPTION
Revising a REC is a fairly complicated piece of the Process. The 4 subsections that deal with making revisions for class 1 through 4 are comparatively simple, but they had very strong similarities between class 1 and 2, and class 3 and 4. Consolidating the text not only makes the whole thing shorter, it also eliminates subtle differences of language that could leave people wondering about potential differences where none were intended or useful.

This PR is an alternative to https://github.com/w3c/w3process/pull/865. It merges the 4 subsections into 3 rather than into 2, to keep "new features" distinct, so as not to make reading about class 3 changes more complicated for those who don't care about class 4.

This is a small part in addressing #700


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/878.html" title="Last updated on May 22, 2024, 4:49 PM UTC (5d569c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/878/8b48f80...frivoal:5d569c1.html" title="Last updated on May 22, 2024, 4:49 PM UTC (5d569c1)">Diff</a>