### PR TITLE
Give the Advisory Board a mission statement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -872,27 +872,30 @@ Advisory Board (AB)</h4>
 <h5 id=ab-role>
 Role of the Advisory Board</h5>
 
-	The <dfn export lt="Advisory Board|AB">Advisory Board</dfn> provides ongoing guidance to the Team
+	The <dfn export lt="Advisory Board|AB">Advisory Board</dfn>
+	is elected by the Membership to advance the effectiveness of W3C as a community by:
+
+	<ul>
+	<li>Providing ongoing guidance to the Team
 	on issues of strategy,
 	management,
 	legal matters,
 	process,
+	community engagement,
 	and conflict resolution.
-	The Advisory Board also serves the Members
+	<li>Serving the Members
 	by tracking issues raised between Advisory Committee meetings,
 	soliciting Member comments on such issues,
 	and proposing actions to resolve these issues.
-	The Advisory Board manages the <a href="#GAProcess">evolution of the Process Document</a>.
-	As part of a [=W3C Council=],
-	members of the [=Advisory Board=] hear and adjudicate on [=Submission Appeals=]
-	and [=Formal Objections=].
+	<li>Managing the <a href="#GAProcess">evolution of the Process Document</a>.
+	</ul>
 
 	The [=Advisory Board=] is distinct from the [=Board of Directors=]
-	and has no decision-making authority within W3C;
+	and has no decision-making authority over W3C;
 	its role is strictly advisory.
-
-	Note: While the [=AB=] as such does not have decision-making authority,
-	its members do when sitting as part of a [=W3C Council=].
+	However, as part of a [=W3C Council=],
+	members of the [=Advisory Board=] hear and adjudicate on [=Submission Appeals=]
+	and [=Formal Objections=].
 
 	Details about the Advisory Board
 	(e.g., the list of Advisory Board participants,

--- a/index.bs
+++ b/index.bs
@@ -894,7 +894,7 @@ Role of the Advisory Board</h5>
 	and has no decision-making authority over W3C;
 	its role is strictly advisory.
 	However, as part of a [=W3C Council=],
-	members of the [=Advisory Board=] hear and adjudicate on [=Submission Appeals=]
+	members of the [=Advisory Board=] hear and adjudicate [=Submission Appeals=]
 	and [=Formal Objections=].
 
 	Details about the Advisory Board

--- a/index.bs
+++ b/index.bs
@@ -873,7 +873,7 @@ Advisory Board (AB)</h4>
 Role of the Advisory Board</h5>
 
 	The <dfn export lt="Advisory Board|AB">Advisory Board</dfn>
-	is elected by the Membership to advance the effectiveness of W3C as a community by:
+	is elected by the Membership to advance the effectiveness of W3C as a standards development organization (<abbr title="standards development organization">SDO</abbr>) by:
 
 	<ul>
 	<li>Providing ongoing guidance to the Team

--- a/index.bs
+++ b/index.bs
@@ -873,26 +873,25 @@ Advisory Board (AB)</h4>
 Role of the Advisory Board</h5>
 
 	The <dfn export lt="Advisory Board|AB">Advisory Board</dfn>
-	is elected by the Membership to advance the effectiveness of W3C as a standards development organization (<abbr title="standards development organization">SDO</abbr>) by:
+	is elected by the Membership to advance the effectiveness of W3C as a standards development organization (<abbr title="standards development organization">SDO</abbr>). The Advisory Board:
 
 	<ul>
-	<li>Providing ongoing guidance to the Team
+	<li>Provides ongoing guidance to the Team
 	on issues of strategy,
 	management,
 	legal matters,
 	process,
 	community engagement,
 	and conflict resolution.
-	<li>Serving the Members
+	<li>Serves the Members
 	by tracking issues raised between Advisory Committee meetings,
 	soliciting Member comments on such issues,
 	and proposing actions to resolve these issues.
-	<li>Managing the <a href="#GAProcess">evolution of the Process Document</a>.
+	<li>Owns the <a href="#GAProcess">Process Document</a>, which includes considering proposals, approving changes, and publishing new versions.
 	</ul>
 
 	The [=Advisory Board=] is distinct from the [=Board of Directors=]
-	and has no decision-making authority over W3C;
-	its role is strictly advisory.
+	and has no decision-making authority over W3C.
 	However, as part of a [=W3C Council=],
 	members of the [=Advisory Board=] hear and adjudicate [=Submission Appeals=]
 	and [=Formal Objections=].

--- a/index.bs
+++ b/index.bs
@@ -875,12 +875,16 @@ Role of the Advisory Board</h5>
 	The <dfn export lt="Advisory Board|AB">Advisory Board</dfn>
 	is elected by the Membership to advance the effectiveness of W3C as a
 	standards development organization (<abbr title="standards development organization">SDO</abbr>).
-	The [=Advisory Board=] has the following responsibilities:
+	The [=Advisory Board=]:
 
 	<ul>
 	<li>Provides ongoing guidance to the Team
-	on issues of strategy, management, legal matters, process, community
-	engagement, and conflict resolution;
+	on issues of strategy, 
+	management, 
+	legal matters, 
+	process, 
+	community engagement, 
+	and conflict resolution;
 	<li>Serves the Members by tracking issues raised between Advisory Committee
 	meetings, soliciting Member comments on such issues, and proposing actions
 	to resolve these issues;

--- a/index.bs
+++ b/index.bs
@@ -890,9 +890,9 @@ Role of the Advisory Board</h5>
 	tracking issues raised between Advisory Committee meetings,
 	soliciting Member comments on such issues,
 	and proposing actions to resolve these issues;
-	<li>Has responsibility for the <a href="#GAProcess">Process Document</a>,
+	<li>Is responsible for the development of the <a href="#GAProcess">Process Document</a>,
 	including considering proposals,
-	approving changes,
+	identifying changes and areas for improvement,
 	and publishing new versions.
 	</ul>
 

--- a/index.bs
+++ b/index.bs
@@ -886,7 +886,7 @@ Role of the Advisory Board</h5>
 	community engagement, 
 	and conflict resolution;
 	<li>Serves the Members by
-	tracking issues raised between Advisory Committee	meetings,
+	tracking issues raised between Advisory Committee meetings,
 	soliciting Member comments on such issues,
 	and proposing actions to resolve these issues;
 	<li>Owns the <a href="#GAProcess">Process Document</a>,

--- a/index.bs
+++ b/index.bs
@@ -889,7 +889,8 @@ Role of the Advisory Board</h5>
 	to resolve these issues.
 	<li>Takes part in [=W3C Councils=] to hear and adjudicate
 	[=Submission Appeals=] and [=Formal Objections=].
-	<li>Owns the <a href="#GAProcess">Process Document</a>, which includes considering proposals, approving changes, and publishing new versions.
+	<li>Owns the <a href="#GAProcess">Process Document</a>, which includes
+	considering proposals, approving changes, and publishing new versions.
 	</ul>
 
 

--- a/index.bs
+++ b/index.bs
@@ -881,13 +881,9 @@ Role of the Advisory Board</h5>
 	The [=Advisory Board=]:
 
 	<ul>
-	<li>Provides ongoing guidance to the Team
-	on issues of strategy,
-	management,
-	legal matters,
-	process,
-	community engagement,
-	and conflict resolution.
+	<li>Provides ongoing guidance to the Team and the [=Board of Directors=]
+	on issues of strategy, management, legal matters, process, community
+	engagement, and conflict resolution.
 	<li>Serves the Members
 	by tracking issues raised between Advisory Committee meetings,
 	soliciting Member comments on such issues,

--- a/index.bs
+++ b/index.bs
@@ -890,8 +890,8 @@ Role of the Advisory Board</h5>
 	tracking issues raised between Advisory Committee meetings,
 	soliciting Member comments on such issues,
 	and proposing actions to resolve these issues;
-	<li>Owns the <a href="#GAProcess">Process Document</a>,
-	which includes considering proposals,
+	<li>Has responsibility for the <a href="#GAProcess">Process Document</a>,
+	including considering proposals,
 	approving changes,
 	and publishing new versions.
 	</ul>

--- a/index.bs
+++ b/index.bs
@@ -884,7 +884,8 @@ Role of the Advisory Board</h5>
 	legal matters, 
 	process, 
 	community engagement, 
-	and conflict resolution;
+	and conflict resolution,
+	that arise during the the work of the W3C community;
 	<li>Serves the Members by
 	tracking issues raised between Advisory Committee meetings,
 	soliciting Member comments on such issues,

--- a/index.bs
+++ b/index.bs
@@ -875,13 +875,10 @@ Role of the Advisory Board</h5>
 	The <dfn export lt="Advisory Board|AB">Advisory Board</dfn>
 	is elected by the Membership to advance the effectiveness of W3C as a
 	standards development organization (<abbr title="standards development organization">SDO</abbr>).
-	
-	The [=Advisory Board=] is distinct from the [=Board of Directors=] and has
-	a distinct set of responsibilities.
-	The [=Advisory Board=]:
+	The [=Advisory Board=] has the following responsibilities:
 
 	<ul>
-	<li>Provides ongoing guidance to the Team and the [=Board of Directors=]
+	<li>Provides ongoing guidance to the Team
 	on issues of strategy, management, legal matters, process, community
 	engagement, and conflict resolution;
 	<li>Serves the Members by tracking issues raised between Advisory Committee

--- a/index.bs
+++ b/index.bs
@@ -883,12 +883,12 @@ Role of the Advisory Board</h5>
 	<ul>
 	<li>Provides ongoing guidance to the Team and the [=Board of Directors=]
 	on issues of strategy, management, legal matters, process, community
-	engagement, and conflict resolution.
+	engagement, and conflict resolution;
 	<li>Serves the Members by tracking issues raised between Advisory Committee
 	meetings, soliciting Member comments on such issues, and proposing actions
-	to resolve these issues.
+	to resolve these issues;
 	<li>Takes part in [=W3C Councils=] to hear and adjudicate
-	[=Submission Appeals=] and [=Formal Objections=].
+	[=Submission Appeals=] and [=Formal Objections=];
 	<li>Owns the <a href="#GAProcess">Process Document</a>, which includes
 	considering proposals, approving changes, and publishing new versions.
 	</ul>

--- a/index.bs
+++ b/index.bs
@@ -891,8 +891,8 @@ Role of the Advisory Board</h5>
 	considering proposals, approving changes, and publishing new versions.
 	</ul>
 
-Members of the [=AB=] also take part in [=W3C Councils=] to hear and adjudicate
-	[=Submission Appeals=] and [=Formal Objections=].
+    Members of the [=AB=] also take part in [=W3C Councils=] to hear and
+	adjudicate [=Submission Appeals=] and [=Formal Objections=].
 	
 	Details about the Advisory Board
 	(e.g., the list of Advisory Board participants,

--- a/index.bs
+++ b/index.bs
@@ -893,6 +893,7 @@ Role of the Advisory Board</h5>
 
 Members of the [=AB=] also take part in [=W3C Councils=] to hear and adjudicate
 	[=Submission Appeals=] and [=Formal Objections=].
+	
 	Details about the Advisory Board
 	(e.g., the list of Advisory Board participants,
 	mailing list information, and summaries of Advisory Board meetings)

--- a/index.bs
+++ b/index.bs
@@ -884,10 +884,9 @@ Role of the Advisory Board</h5>
 	<li>Provides ongoing guidance to the Team and the [=Board of Directors=]
 	on issues of strategy, management, legal matters, process, community
 	engagement, and conflict resolution.
-	<li>Serves the Members
-	by tracking issues raised between Advisory Committee meetings,
-	soliciting Member comments on such issues,
-	and proposing actions to resolve these issues.
+	<li>Serves the Members by tracking issues raised between Advisory Committee
+	meetings, soliciting Member comments on such issues, and proposing actions
+	to resolve these issues.
 	<li>Takes part in [=W3C Councils=] to hear and adjudicate
 	[=Submission Appeals=] and [=Formal Objections=].
 	<li>Owns the <a href="#GAProcess">Process Document</a>, which includes considering proposals, approving changes, and publishing new versions.

--- a/index.bs
+++ b/index.bs
@@ -885,15 +885,19 @@ Role of the Advisory Board</h5>
 	process, 
 	community engagement, 
 	and conflict resolution;
-	<li>Serves the Members by tracking issues raised between Advisory Committee
-	meetings, soliciting Member comments on such issues, and proposing actions
-	to resolve these issues;
-	<li>Owns the <a href="#GAProcess">Process Document</a>, which includes
-	considering proposals, approving changes, and publishing new versions.
+	<li>Serves the Members by
+	tracking issues raised between Advisory Committee	meetings,
+	soliciting Member comments on such issues,
+	and proposing actions to resolve these issues;
+	<li>Owns the <a href="#GAProcess">Process Document</a>,
+	which includes considering proposals,
+	approving changes,
+	and publishing new versions.
 	</ul>
 
-    Members of the [=AB=] also take part in [=W3C Councils=] to hear and
-	adjudicate [=Submission Appeals=] and [=Formal Objections=].
+    Members of the [=AB=] also take part in [=W3C Councils=]
+    to hear and adjudicate [=Formal Objections=]
+    and [=Submission Appeals=].
 	
 	Details about the Advisory Board
 	(e.g., the list of Advisory Board participants,

--- a/index.bs
+++ b/index.bs
@@ -887,13 +887,12 @@ Role of the Advisory Board</h5>
 	<li>Serves the Members by tracking issues raised between Advisory Committee
 	meetings, soliciting Member comments on such issues, and proposing actions
 	to resolve these issues;
-	<li>Takes part in [=W3C Councils=] to hear and adjudicate
-	[=Submission Appeals=] and [=Formal Objections=];
 	<li>Owns the <a href="#GAProcess">Process Document</a>, which includes
 	considering proposals, approving changes, and publishing new versions.
 	</ul>
 
-
+Members of the [=AB=] also take part in [=W3C Councils=] to hear and adjudicate
+	[=Submission Appeals=] and [=Formal Objections=].
 	Details about the Advisory Board
 	(e.g., the list of Advisory Board participants,
 	mailing list information, and summaries of Advisory Board meetings)

--- a/index.bs
+++ b/index.bs
@@ -873,7 +873,12 @@ Advisory Board (AB)</h4>
 Role of the Advisory Board</h5>
 
 	The <dfn export lt="Advisory Board|AB">Advisory Board</dfn>
-	is elected by the Membership to advance the effectiveness of W3C as a standards development organization (<abbr title="standards development organization">SDO</abbr>). The Advisory Board:
+	is elected by the Membership to advance the effectiveness of W3C as a
+	standards development organization (<abbr title="standards development organization">SDO</abbr>).
+	
+	The [=Advisory Board=] is distinct from the [=Board of Directors=] and has
+	a distinct set of responsibilities.
+	The [=Advisory Board=]:
 
 	<ul>
 	<li>Provides ongoing guidance to the Team
@@ -887,14 +892,11 @@ Role of the Advisory Board</h5>
 	by tracking issues raised between Advisory Committee meetings,
 	soliciting Member comments on such issues,
 	and proposing actions to resolve these issues.
+	<li>Takes part in [=W3C Councils=] to hear and adjudicate
+	[=Submission Appeals=] and [=Formal Objections=].
 	<li>Owns the <a href="#GAProcess">Process Document</a>, which includes considering proposals, approving changes, and publishing new versions.
 	</ul>
 
-	The [=Advisory Board=] is distinct from the [=Board of Directors=]
-	and has no decision-making authority over W3C.
-	However, as part of a [=W3C Council=],
-	members of the [=Advisory Board=] hear and adjudicate [=Submission Appeals=]
-	and [=Formal Objections=].
 
 	Details about the Advisory Board
 	(e.g., the list of Advisory Board participants,


### PR DESCRIPTION
Tries to tie together the [various roles of the AB](https://www.w3.org/policies/process/#ab-role) under a coherent mission statement, [similar to the TAG](https://www.w3.org/policies/process/#tag-role).

Based on discussions captured in
-  https://github.com/w3c/AB-memberonly/issues/248
-  https://www.w3.org/2025/03/26-ABpurpose-minutes.html
-  https://www.w3.org/2025/Talks/AC/ab-wendy-reid/slides.pdf