### PR TITLE
Editorial reorg of text defining REC track statuses

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3459,7 +3459,7 @@ The W3C Recommendation Track</h3>
 	and if there is support from its Membership,
 	W3C publishes it as a <a href="#RecsW3C">Recommendation</a>.
 
-	In summary, the <dfn lt="W3C Recommendation Track | REC Track | Recommendation Track | Recommendation-track">W3C Recommendation Track</dfn> consists of:
+	In summary, the main steps of <dfn lt="W3C Recommendation Track | REC Track | Recommendation Track | Recommendation-track">W3C Recommendation Track</dfn> are:
 
 	<ol>
 		<li>Publication of the [=First Public Working Draft=].


### PR DESCRIPTION
* Switched the definition of REC track to point to the full list of maturity stages, rather than the summarized version of it.
* Move a few paragraphs around, for ease of reading


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1079.html" title="Last updated on Jul 23, 2025, 2:45 PM UTC (3ca4615)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1079/d11049d...frivoal:3ca4615.html" title="Last updated on Jul 23, 2025, 2:45 PM UTC (3ca4615)">Diff</a>