### PR TITLE
Adjust language for getting patent policy comittments from non-participants

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3429,10 +3429,14 @@ License Grants from Non-Participants</h4>
 
 	When a proposal for a change in class 3 or 4
 	(as described in [[#correction-classes]]) to a [=technical report=]
-	originates from or contains substantive contributions by a party not already obligated under the patent Policy,
+	originates from or contains substantive contributions by
+	any parties not already obligated under the patent Policy,
 	the [=Team=] <em class=rfc2119>must</em> request
-	a recorded royalty-free patent commitment;
-	for a change in class 4, the Team <em class=rfc2119>must</em> <em>secure</em> such commitment.
+	a recorded royalty-free patent commitment
+	from each of those parties;
+	for a change in class 4, 
+	the Team <em class=rfc2119>must</em> <em>secure</em> such commitments 
+	from each and every such party.
 	Such commitment <em class=rfc2119>should</em> cover,
 	at a minimum,
 	all the party's Essential Claims both in the contribution,

--- a/index.bs
+++ b/index.bs
@@ -3428,7 +3428,7 @@ Maintenance Without a Group</h4>
 License Grants from Non-Participants</h4>
 
 	When a proposal for a change in class 3 or 4
-	(as described in [[#correction-classes]]) to a technical report under this process
+	(as described in [[#correction-classes]]) to a [=technical report=]
 	originates from or contains substantive contributions by a party not already obligated under the patent Policy,
 	the [=Team=] <em class=rfc2119>must</em> request
 	a recorded royalty-free patent commitment;

--- a/index.bs
+++ b/index.bs
@@ -3427,9 +3427,9 @@ Maintenance Without a Group</h4>
 <h4 id="contributor-license">
 License Grants from Non-Participants</h4>
 
-	When a party who is not already obligated under the Patent Policy
-	offers a change in class 3 or 4
+	When a proposal for a change in class 3 or 4
 	(as described in [[#correction-classes]]) to a technical report under this process
+	originates from or contains substantive contributions by a party not already obligated under the patent Policy,
 	the [=Team=] <em class=rfc2119>must</em> request
 	a recorded royalty-free patent commitment;
 	for a change in class 4, the Team <em class=rfc2119>must</em> <em>secure</em> such commitment.

--- a/index.bs
+++ b/index.bs
@@ -3434,7 +3434,7 @@ License Grants from Non-Participants</h4>
 	the [=Team=] <em class=rfc2119>must</em> request
 	a recorded royalty-free patent commitment
 	from each of those parties;
-	for a change in class 4, 
+	for a substantial contribution in class 4, 
 	the Team <em class=rfc2119>must</em> <em>secure</em> such commitments 
 	from each and every such party.
 	Such commitment <em class=rfc2119>should</em> cover,


### PR DESCRIPTION
This makes sure that we seek commitments to the patent policy from the the people who are originating the substance of the change being offered, rather than from those who are doing the mechanical work of offering them.

Note: This aligns with current Team practices and existing tooling.

Addresses #903


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1129.html" title="Last updated on Apr 13, 2026, 8:13 PM UTC (7ff3a5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1129/ff011e6...frivoal:7ff3a5e.html" title="Last updated on Apr 13, 2026, 8:13 PM UTC (7ff3a5e)">Diff</a>