### PR TITLE
Harmonize the affiliation constraints for the AB and TAG

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1118,23 +1118,16 @@ Elected Groups Participation Constraints</h5>
 
 	<ul>
 		<li>
-			Two participants with the same [=primary affiliation=] per <a href="#AB-TAG-elections"></a>
-			must not both occupy elected seats on the TAG
+			Two (or more) participants with the same [=primary affiliation=] per <a href="#AB-TAG-elections"></a>
+			must not occupy elected seats on the same [=Elected Group=],
 			except when this is caused by a change of affiliation of an existing participant.
-			At the completion of the next regularly scheduled election for the TAG,
+			At the completion of the next regularly scheduled election for that group,
 			the organization <em class="rfc2119">must</em> have returned to having at most one seat.
-
-		<li>
-			Two participants with the same [=primary affiliation=] per <a href="#AB-TAG-elections"></a>
-			must not both occupy elected seats on the AB.
-			If, for whatever reason, these constraints are not satisfied
-			(e.g., because an [=AB=] participant changes jobs),
-			one participant <em class="rfc2119">must</em> cease [=AB=] participation
-			until the situation has been resolved.
-			If after <span class="time-interval">30 days</span> the situation has not been resolved,
-			the Chair will apply
+			Otherwise, the [=Team=] will apply
 			the <a href="#random">verifiable random selection procedure</a> described below
-			to choose one person for continued participation and declare the other seat(s) vacant.
+			to choose one person for continued participation and declare the other seat(s) vacant
+			as of that election.
+
 		<li>
 			An individual <em class="rfc2119">must not</em> participate on both the TAG and the AB.
 	</ul>


### PR DESCRIPTION
As discussed in #817, since there is no clear ongoing reason to justify the difference of treatment between the AB and TAG when affiliation changes cause two or more participants to share the same affiliation, this PR proposes to harmonize the rules for the two groups, by aligning on the more lenient one in terms of duration (the TAG's) while keeping details from the more specific one (the AB's) in terms of backstop.

Note: I have also switched the responsibility for running (if necessary) the [verifiable random selection procedure](file:///Users/florian/src/w3c/process/index.html#random) from the Chair to the Team, as this is a purely administrative yet fiddly step, whose timing would now be tied to the election, which is already run by the Team. So that seemed simpler. We can of course switch back if there's a preference to that effect.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1167.html" title="Last updated on Jun 11, 2026, 6:43 AM UTC (83f63b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1167/dfd4388...frivoal:83f63b8.html" title="Last updated on Jun 11, 2026, 6:43 AM UTC (83f63b8)">Diff</a>