### PR TITLE
Make it so that all RECs can gain new features & simplify terminology accordingly

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3366,8 +3366,8 @@ Errata Management</h4>
 	Inline errata are treated as <a href="#class-2">class 2 changes</a>,
 	and are published accordingly.
 
-	An [=erratum=] <em class="rfc2119">may</em> be accompanied [=candidate amendment=]
-	proposing a solution to the issue.
+	An [=erratum=] <em class="rfc2119">may</em> be accompanied by a 
+	[=candidate amendment=] proposing a solution to the issue.
 
 <h4 id=candidate-amendments oldids=candidate-changes>
 Candidate Amendments</h4>

--- a/index.bs
+++ b/index.bs
@@ -3374,7 +3374,7 @@ Candidate Amendments</h4>
 
 	A <dfn>candidate amendment</dfn> is a non-normative annotation,
 	marked as such,
-	included into a [=technical report=] by [=group decision=]
+	integrated into a [=technical report=] by [=group decision=]
 	to indicate a potential [=substantive change=]
 	that has not yet been formally adopted.
 	They are treated as <a href="#class-2">class 2 changes</a>,

--- a/index.bs
+++ b/index.bs
@@ -4291,12 +4291,6 @@ Incorporating Candidate Amendments</h5>
 	The announcement <em class="rfc2119">must</em>:
 	<ul>
 		<li>
-			Identify whether this is a
-			<dfn>Last Call for Review of Proposed Corrections</dfn>,
-			<dfn>Last Call for Review of Proposed Additions</dfn>,
-			or <dfn>Last Call for Review of Proposed Corrections and Additions</dfn>.
-
-		<li>
 			Identify the specific [=candidate amendments=] under review
 			as <dfn>proposed amendments</dfn>
 			(<dfn export>proposed corrections</dfn>/<dfn oldids="proposed-addition" export>proposed additions</dfn>).
@@ -4669,7 +4663,7 @@ Revising W3C Statements</h4>
 	an [=Advisory Committee review=] of the changes it wishes to incorporate.
 	The specific [=candidate amendments=] under review
 	<em class=rfc2119>must</em> be identified as [=proposed amendments=]
-	just as in a [=Last Call for Review of Proposed Corrections=].
+	just as in a [=Last Call for Review of Proposed Amendments=].
 
 	The decision to incorporate [=proposed amendments=] into [=W3C Statement=] is a [=W3C Decision=].
 	[=Advisory Committee representatives=] may initiate an [=Advisory Committee Appeal=] of the decision.
@@ -5443,6 +5437,16 @@ Appendix A: Retired Terminology</h2>
 		<dd>
 			Last defined <a href="https://www.w3.org/policies/process/20250818/#allow-new-features">in section 6.3.1 of the 2025 Process</a>.
 			See also <a href="#allow-features-note">the note</a> at the end of [[#revised-rec-substantive]].
+
+		<dt>
+			<dfn noexport>Last Call for Review of Proposed Corrections</dfn>,
+			<dfn noexport>Last Call for Review of Proposed Additions</dfn>, and
+			<dfn noexport>Last Call for Review of Proposed Corrections and Additions</dfn>
+			(retired terms)
+		<dd>
+			Last defined in <a href="https://www.w3.org/policies/process/20250818/#change-review">section 6.3.10.4 of the 2025 Process</a>.
+			All were subtypes of [=Last Call for Review of Proposed Amendments=],
+			and are no longer formally distinguished.
 	</dl>
 
 <h2 id="acks" class="non-normative nonum">

--- a/index.bs
+++ b/index.bs
@@ -3635,15 +3635,6 @@ Maturity Stages on the Recommendation Track</h4>
 			(in accordance with [[#revising-rec]])
 			to address [=editorial change|editorial=] or [=substantive change|substantive=] issues
 			that are discovered later.
-			However, <a href=#class-4>new features</a> can only be added
-			if the document already identifies itself
-			as intending to <dfn>allow new features</dfn>.
-			Adding or removing this allowance is a [=substantive change=].
-			Such an allowance cannot be added
-			to a [=technical report=] previously published as a [=Recommendation=]
-			that did not allow such changes;
-			this requires a new [=technical report=]
-			(which could, for example, be similarly named but with an incremented version number).
 
 			As technology evolves,
 			a [=W3C Recommendation=] may become:
@@ -4161,20 +4152,10 @@ Requirements for Transition</h5>
 			<em class="rfc2119">must</em> identify, in the document, where errata are tracked.
 	</ul>
 
-	Additionally,
-	if the document has previously been published as a [=W3C Recommendation=], the [=Working Group=]
-	<em class=rfc2119>must not</em> include any <a href="#correction-classes">class 4 change</a>
-	to that publication
-	unless it was explicitly marked as [=allowing new features=],
-	and <em class=rfc2119>must not</em> include any such marking
-	if not already present.
-
 	If the document's most recent publication is a [=Candidate Recommendation Draft=],
 	the [=Team=] <em class=rfc2119>must</em> verify
 	that it contains no changes since the previous [=Candidate Recommendation Snapshot=] other than:
 	* [=editorial changes=],
-	* the addition or removal of a statement as to whether the document will [=allow new features=]
-		after its publication as a [=Recommendation=].
 	* dropping [=at risk=] features
 
 	Otherwise, the [=Working Group=] <em class=rfc2119>must</em> republish it
@@ -4255,18 +4236,19 @@ Revising a Recommendation: Editorial Changes</h5>
 	to make this class of change without passing through earlier maturity stages.
 	(See <a href="#class-1">class 1</a> and <a href="#class-2">class 2 changes</a>.)
 
-<h5 id="revised-rec-substantive">
+<h5 id="revised-rec-substantive" oldids="revised-rec-features">
 Revising a Recommendation: Substantive Changes</h5>
 
-	Tentative corrections (see <a href="#class-3">class 3 changes</a>)
+	Tentative [=substantive changes=]
+	(see <a href="#class-3">class 3</a> and <a href="#class-4">class 4 changes</a>.)
 	<em class=rfc2119>may</em> be annotated into a [=Recommendation=]
-	using [=candidate corrections=].
+	using [=candidate amendments=].
 
-	Note: [=Candidate corrections=] do not normatively modify the document;
+	Note: [=Candidate amendments=] do not normatively modify the document;
 	they editorially indicate how one might do so.
 	They are therefore published following the provisions of [[#revised-rec-editorial]].
 
-	A [=candidate correction=] can be made normative
+	A [=candidate amendment=] can be made normative
 	and be folded into the main text of the [=Recommendation=],
 	once it has satisfied all the same criteria
 	as the rest of the [=Recommendation=],
@@ -4283,30 +4265,19 @@ Revising a Recommendation: Substantive Changes</h5>
 	or, if the relevant criteria are fulfilled,
 	<a href="#transition-cr">publish as a Candidate Recommendation</a>--
 	and advance the specification from that state.
-	(See <a href="#correction-classes">class 3 changes</a>.)
 
-<h5 id="revised-rec-features">
-Revising a Recommendation: New Features</h5>
-
-	For [=Recommendations=] explicitly identified as [=allow new features|allowing new features=],
-	tentative new features (see <a href="#correction-classes">class 4 changes</a>)
-	<em class=rfc2119>may</em> be added as [=candidate additions=] in annotations,
-	and <a href="#correction-classes">class 4 changes</a> may be normatively incorporated
-	in the same fashion as <a href="#correction-classes">class 3 changes</a> in [[#revised-rec-substantive]].
-
-	Note: Limiting the addition of new features to [=Recommendations=] that explicitly allow them
-	enables third parties to depend on a stable feature-set for [=Recommendations=] that do not advertise that ability,
-	as was the case for all [=Recommendations=] prior to the 2020 revision of this Process.
-
-	Note: When a [=Recommendation=] does not [=allow new features=],
-	new features can be added by creating a new [=technical report=]
-	and following the full process of advancing that [=technical report=] to [=Recommendation=]--
-	beginning with a new [=First Public Working Draft=].
-	Such [=technical reports=] could be written to represent
-	additional modules building on top of the original [=Recommendation=] of the core technology,
-	or an expanded replacement of the original [=Recommendation=] of the core technology
-	(in which case the new [=technical report=] will typically have the same name as the original,
-	with an incremented version number).
+	<div id=allow-features-note class=note>
+		<span class=marker>Note:</span>
+		In earlier version of the Process,
+		new features (<a href="#class-4">class 4 changes</a>) could only be added to [=Recommendations=]
+		that had explicitly opted into this ability
+		prior to their first publication as [=Recommendation=].
+		Otherwise,
+		new features could only be added by creating a new [=technical report=]
+		and following the full process of advancing that [=technical report=] to [=Recommendation=]--
+		beginning with a new [=First Public Working Draft=].
+		For simplicity, this restriction has been lifted.
+	</div>
 
 <h5 id=change-review>
 Incorporating Candidate Amendments</h5>
@@ -4344,10 +4315,6 @@ Incorporating Candidate Amendments</h5>
 	for the purposes of the Patent Policy [[PATENT-POLICY]].
 	Also, the review initiated by the [=Last Call for Review of Proposed Amendments=]
 	is an [=Advisory Committee Review=].
-
-	Note: [=Last Call for Review of Proposed Additions=] and
-	[=Last Call for Review of Proposed Corrections and Additions=]
-	can only be issued for [=Recommendations=] that [=allow new features=].
 
 	A [=Working Group=] <em class="rfc2119">may</em> batch
 	multiple [=proposed amendments=] into a single <a>Last Call for Review of Proposed Amendments</a>.
@@ -5469,6 +5436,13 @@ Appendix A: Retired Terminology</h2>
 		<dd>
 			Last defined <a href="https://www.w3.org/2014/Process-20140801/#def-W3CChair">in section 2.2 of the 2014 Process</a>,
 			now called [=CEO=].
+
+		<dt>
+			<dfn noexport>Allow new features</dfn>
+			(retired term)
+		<dd>
+			Last defined <a href="https://www.w3.org/policies/process/20250818/#allow-new-features">in section 6.3.1 of the 2025 Process</a>.
+			See also <a href="#allow-features-note">the note</a> at the end of [[#revised-rec-substantive]].
 	</dl>
 
 <h2 id="acks" class="non-normative nonum">

--- a/index.bs
+++ b/index.bs
@@ -3363,17 +3363,21 @@ Errata Management</h4>
 	be annotated inline
 	alongside the affected [=technical report=] text
 	or at the start or end of the most relevant section(s).
+	Inline errata are treated as <a href="#class-2">class 2 changes</a>,
+	and are published accordingly.
+
+	An [=erratum=] <em class="rfc2119">may</em> be accompanied [=candidate amendment=]
+	proposing a solution to the issue.
 
 <h4 id=candidate-amendments oldids=candidate-changes>
 Candidate Amendments</h4>
 
-	An [=erratum=] <em class="rfc2119">may</em> be accompanied by a non-normative,
-	<dfn>candidate correction</dfn> approved by [=group decision=].
-	When annotated inline,
-	errata--
-	including their [=candidate corrections=]--
-	must be marked as such,
-	are treated as <a href="#correction-classes">class 2 changes</a>,
+	A <dfn>candidate amendment</dfn> is a non-normative annotation,
+	marked as such,
+	included into a [=technical report=] by [=group decision=]
+	to indicate a potential [=substantive change=]
+	that has not yet been formally adopted.
+	They are treated as <a href="#class-2">class 2 changes</a>,
 	and are published accordingly.
 
 	Note: Annotating changes in this way allows more mature documents
@@ -3382,13 +3386,6 @@ Candidate Amendments</h4>
 	even when the [=candidate amendments=] have not yet received
 	sufficient review or implementation experience
 	to be normatively incorporated into the specification proper.
-
-	A <dfn>candidate addition</dfn> is similar to a [=candidate correction=],
-	except that it proposes a new feature
-	rather than an error correction.
-
-	[=Candidate corrections=] and [=candidate additions=] are collectively known as
-	<dfn lt="candidate amendment">candidate amendments</dfn>.
 
 	In addition to their actual [[#maturity-stages|maturity stage]],
 	[=published=] [=REC Track=] documents with [=candidate amendments=] are also considered,
@@ -3406,7 +3403,7 @@ Maintenance Without a Group</h4>
 	<ol>
 		<li><a href="#class-1">class 1 changes</a>;
 		<li>inline [=errata=];
-		<li>[=candidate corrections=],
+		<li>[=candidate amendments=] not including <a href="#class-4">class 4 changes</a>,
 			which <em class=rfc2119>must</em> be marked as <dfn>Team correction</dfn>;
 		<li><a href="#class-2">class 2 changes</a> other than inline [=errata=] and [=Team corrections=].
 	</ol>
@@ -4292,8 +4289,7 @@ Incorporating Candidate Amendments</h5>
 	<ul>
 		<li>
 			Identify the specific [=candidate amendments=] under review
-			as <dfn>proposed amendments</dfn>
-			(<dfn export>proposed corrections</dfn>/<dfn oldids="proposed-addition" export>proposed additions</dfn>).
+			as <dfn>proposed amendments</dfn>.
 
 		<li>
 			Specify the deadline for review comments,
@@ -5437,6 +5433,20 @@ Appendix A: Retired Terminology</h2>
 		<dd>
 			Last defined <a href="https://www.w3.org/policies/process/20250818/#allow-new-features">in section 6.3.1 of the 2025 Process</a>.
 			See also <a href="#allow-features-note">the note</a> at the end of [[#revised-rec-substantive]].
+
+		<dt>
+			<dfn noexport>Candidate correction</dfn> and <dfn noexport>candidate addition</dfn>
+			(retired terms)
+		<dd>
+			Last defined in <a href="https://www.w3.org/policies/process/20250818/#candidate-amendments">section 6.2.5 of the 2025 Process</a>.
+			Both were subtypes of [=candidate amendment=] and are no longer formally distinguished.
+
+		<dt>
+			<dfn noexport>Proposed corrections</dfn> and <dfn oldids="proposed-addition" export>proposed additions</dfn>
+			(retired terms)
+		<dd>
+			Last defined in <a href="https://www.w3.org/policies/process/20250818/#change-review">section 6.3.10.4 of the 2025 Process</a>.
+			Both were subtypes of [=proposed amendment=] and are no longer formally distinguished.
 
 		<dt>
 			<dfn noexport>Last Call for Review of Proposed Corrections</dfn>,


### PR DESCRIPTION
This pull request implements the AB resolution documented in https://github.com/w3c/AB-memberonly/issues/244#issuecomment-4303099327, doing away with the distinction between Recommendations that allow new features and those that do not. This enables a simplification of Process rules and terminology.

This is notable in that it breaks a long standing guarantee previously offered by the Process. Until now, unless they contained an explicit statement to the contrary (know as "allowing new features"), documents could not gain new features after their initial publication as Recommendations, even as editorial improvements or bug fixes were being added through updates. References could be made to them using their *undated* URL while being confident that the scope/featureset would not change.

However, it was found that the terminology and process mechanics needed to maintain this distinction was the source of much confusion, while there is scant evidence that anybody actually depended on this guarantee. (People who want to depend on a Recommendation not changing at all after publication can continue to do so, as they always have, but using the *dated* URL for that publication).

This PR is organized in 3 commits, applying progressively stronger simplifications in terminology.
Together (and not counting the 31 lines added the "Retired terminology" appendix), they results in a net reduction of 43 lines (+33  -76), and retirement of 8 `dfn`ed terms.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1168.html" title="Last updated on Jun 12, 2026, 1:45 AM UTC (bef2f75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1168/ae64962...frivoal:bef2f75.html" title="Last updated on Jun 12, 2026, 1:45 AM UTC (bef2f75)">Diff</a>