### PR TITLE
Remove second occurrence of "changes"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3876,7 +3876,7 @@ Updating Mature Publications on the Recommendation Track</h4>
 			and <em class="rfc2119">should</em> document the details of such changes.
 
 		<li>
-			<em class="rfc2119">should</em> publicly document if [=editorial changes=] changes have been made,
+			<em class="rfc2119">should</em> publicly document if [=editorial changes=] have been made,
 			and <em class="rfc2119">may</em> document the details of such changes.
 
 		<li>


### PR DESCRIPTION
The link text already contains "changes" so there's no need to have it outside the link text.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/process/pull/1172.html" title="Last updated on Jun 23, 2026, 5:35 PM UTC (574f423)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1172/ae64962...574f423.html" title="Last updated on Jun 23, 2026, 5:35 PM UTC (574f423)">Diff</a>