### PR TITLE
Allow alternate AC Reps to attend AC meetings as a matter of course

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -858,7 +858,7 @@ Advisory Committee Meetings</h4>
 	Each Member organization <em class="rfc2119">should</em> send their [=AC representative=]
 	to each Advisory Committee Meeting.
 	Member organizations that have appointed an [=alternate AC representative=]
-	<em class=rfc2119>may</em> send them in addition or instead.
+	<em class=rfc2119>may</em> send them in addition to or instead of their [=AC Representative=].
 
 	The [=Team=] <em class="rfc2119">must</em> announce the date and location of each Advisory Committee meeting
 	no later than at the end of the previous meeting;

--- a/index.bs
+++ b/index.bs
@@ -855,11 +855,10 @@ Advisory Committee Meetings</h4>
 		</dd>
 	</dl>
 
-	Each Member organization <em class="rfc2119">should</em> send one <a href="#member-rep">representative</a>
+	Each Member organization <em class="rfc2119">should</em> send their [=AC representative=]
 	to each Advisory Committee Meeting.
-	In exceptional circumstances
-	(e.g., during a period of transition between representatives from an organization),
-	the meeting Chair <em class="rfc2119">may</em> allow a Member organization to send two representatives to a meeting.
+	Member organizations that have appointed an [=alternate AC representative=]
+	<em class=rfc2119>may</em> send them in addition or instead.
 
 	The [=Team=] <em class="rfc2119">must</em> announce the date and location of each Advisory Committee meeting
 	no later than at the end of the previous meeting;


### PR DESCRIPTION
This replaces the exceptional invitation mechanism that was in place prior to the introduciton of alt AC Reps.

See https://github.com/w3c/process/issues/1092


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1173.html" title="Last updated on Jul 8, 2026, 2:32 PM UTC (6300b21)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1173/658acd5...frivoal:6300b21.html" title="Last updated on Jul 8, 2026, 2:32 PM UTC (6300b21)">Diff</a>