### PR TITLE
Remove AB from TAG appointee ratification

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1291,7 +1291,7 @@ Technical Architecture Group Appointments</h5>
 	The [=Team=]'s choice of appointee(s)
 	is subject to ratification by secret ballot
 	by the [=TAG=],
-	requiring a two-thirds approval.
+	requiring two-thirds approval.
 	In the case of regularly scheduled elections,
 	the [=TAG=] participants in this ratification are
 	its members for the upcoming term.

--- a/index.bs
+++ b/index.bs
@@ -1290,8 +1290,8 @@ Technical Architecture Group Appointments</h5>
 
 	The [=Team=]'s choice of appointee(s)
 	is subject to ratification by secret ballot
-	by both the [=AB=] and the [=TAG=],
-	requiring a two-thirds approval from each.
+	by the [=TAG=],
+	requiring a two-thirds approval.
 	In the case of regularly scheduled elections,
 	the [=TAG=] participants in this ratification are
 	its members for the upcoming term.


### PR DESCRIPTION
Per AB decision, as reported in https://github.com/w3c/process/issues/810.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1178.html" title="Last updated on Jul 9, 2026, 5:04 PM UTC (bd04097)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1178/658acd5...frivoal:bd04097.html" title="Last updated on Jul 9, 2026, 5:04 PM UTC (bd04097)">Diff</a>